### PR TITLE
Add get_object and head_object to the BaseSync.

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -18,6 +18,17 @@ import eventlet
 import logging
 
 
+class ProviderResponse(object):
+    def __init__(self, success, status, headers, body):
+        self.success = success
+        self.status = status
+        self.headers = headers
+        self.body = body
+
+    def to_wsgi(self):
+        return self.status, self.headers.items(), self.body
+
+
 class BaseSync(object):
     """Generic base class that each provider must implement.
 
@@ -132,6 +143,12 @@ class BaseSync(object):
         raise NotImplementedError()
 
     def shunt_object(self, request, name):
+        raise NotImplementedError()
+
+    def get_object(self, key, options={}):
+        raise NotImplementedError()
+
+    def head_object(self, key, options={}):
         raise NotImplementedError()
 
     def list_objects(self, marker, limit, prefix, delimiter):


### PR DESCRIPTION
We need to be able to issue GET requests to the remote containers not
just as part of shunting requests, but also when migrating objects
back into Swift. This patchs expands the existing API, such that the
migrator could LIST and GET all of the objects from the remote store
and stream them into Swift.