### PR TITLE
Simplify the use of the pool context manager.

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -58,7 +58,7 @@ class BaseSync(object):
             self.pool.release()
 
         def __enter__(self):
-            return self
+            return self.client
 
         def __exit__(self, exc_type, exc_value, traceback):
             self.close()

--- a/s3_sync/verify.py
+++ b/s3_sync/verify.py
@@ -47,7 +47,7 @@ def validate_bucket(provider, swift_key, create_bucket):
     if create_bucket:
         # This should only be necessary on Swift; reach down to the client
         with provider.client_pool.get_client() as client:
-            result = client.client.put_container(provider.aws_bucket)
+            result = client.put_container(provider.aws_bucket)
         if result is not None:
             return result
 
@@ -80,7 +80,7 @@ def validate_bucket(provider, swift_key, create_bucket):
     if create_bucket:
         # Clean up after ourselves
         with provider.client_pool.get_client() as client:
-            result = client.client.delete_container(provider.aws_bucket)
+            result = client.delete_container(provider.aws_bucket)
         if result is not None:
             return result
 
@@ -119,9 +119,9 @@ def main(args=None):
         if not args.bucket:
             with provider.client_pool.get_client() as client:
                 if args.protocol == 's3':
-                    client.client.list_buckets()
+                    client.list_buckets()
                 else:
-                    client.client.get_account()
+                    client.get_account()
         else:
             if args.protocol == 's3':
                 swift_key = 'fabcab/cloud_sync_test'

--- a/test/unit/test_verify.py
+++ b/test/unit/test_verify.py
@@ -193,14 +193,14 @@ class TestMainTrackClientCalls(unittest.TestCase):
         ])
         self.assertEqual(exit_arg, 0)
         mock_client = \
-            mock_get_client.return_value.__enter__.return_value.client
+            mock_get_client.return_value.__enter__.return_value
         self.assertEqual(mock_client.mock_calls, [
             mock.call.list_buckets(),
         ])
 
     def test_aws_with_bucket(self, mock_get_client):
         mock_client = \
-            mock_get_client.return_value.__enter__.return_value.client
+            mock_get_client.return_value.__enter__.return_value
         mock_client.head_object.side_effect = [
             None,
             {  # HEAD after PUT
@@ -272,14 +272,14 @@ class TestMainTrackClientCalls(unittest.TestCase):
         ])
         self.assertEqual(exit_arg, 0)
         mock_client = \
-            mock_get_client.return_value.__enter__.return_value.client
+            mock_get_client.return_value.__enter__.return_value
         self.assertEqual(mock_client.mock_calls, [
             mock.call.list_buckets(),
         ])
 
     def test_google_with_bucket(self, mock_get_client):
         mock_client = \
-            mock_get_client.return_value.__enter__.return_value.client
+            mock_get_client.return_value.__enter__.return_value
         mock_client.head_object.side_effect = [
             None,
             {  # HEAD after PUT
@@ -349,14 +349,14 @@ class TestMainTrackClientCalls(unittest.TestCase):
         ])
         self.assertEqual(exit_arg, 0)
         mock_client = \
-            mock_get_client.return_value.__enter__.return_value.client
+            mock_get_client.return_value.__enter__.return_value
         self.assertEqual(mock_client.mock_calls, [
             mock.call.get_account(),
         ])
 
     def test_swift_with_bucket(self, mock_get_client):
         mock_client = \
-            mock_get_client.return_value.__enter__.return_value.client
+            mock_get_client.return_value.__enter__.return_value
         mock_client.head_object.side_effect = [
             None,
             {'x-object-meta-cloud-sync': 'fabcab'},


### PR DESCRIPTION
We can return the connection directly from the context manager, as
opposed to leaking an extra level of indirection.