### PR TITLE
Return connections only after consuming the body.

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -53,12 +53,15 @@ class BaseSync(object):
         def acquire(self):
             return self.semaphore.acquire(blocking=False)
 
+        def close(self):
+            self.semaphore.release()
+            self.pool.release()
+
         def __enter__(self):
             return self
 
         def __exit__(self, exc_type, exc_value, traceback):
-            self.semaphore.release()
-            self.pool.release()
+            self.close()
 
     class HttpClientPool(object):
         def __init__(self, client_factory, max_conns):
@@ -94,6 +97,9 @@ class BaseSync(object):
 
         def release(self):
             self.get_semaphore.release()
+
+        def free_count(self):
+            return self.get_semaphore.balance
 
     def __init__(self, settings, max_conns=10, per_account=False):
         """Base class that every Cloud Sync provider implementation should

--- a/s3_sync/utils.py
+++ b/s3_sync/utils.py
@@ -386,6 +386,80 @@ class SwiftSloPutWrapper(SwiftPutWrapper):
         return chunk
 
 
+class ClosingResourceIterable(object):
+    """
+        Wrapper to ensure the resource is returned back to the pool after the
+        data is consumed.
+    """
+    def __init__(self, resource, data_src, close_callable=None,
+                 read_chunk=65536, length=None):
+        self.closed = False
+        self.exhausted = False
+        self.data_src = data_src
+        self.read_chunk = read_chunk
+        self.resource = resource
+        self.length = length
+        self.amt_read = 0
+
+        if close_callable:
+            self.close_data = close_callable
+        elif hasattr(self.data_src, 'close'):
+            self.close_data = self.data_src.close
+        else:
+            raise ValueError('No closeable to close the data source defined')
+
+        try:
+            iter(self.data_src)
+            self.iterable = True
+        except TypeError:
+            self.iterable = False
+
+        if not self.iterable and not hasattr(self.data_src, 'read'):
+            raise TypeError('Cannot iterate over the data source')
+        if not self.iterable and length is None:
+            raise ValueError('Must supply length with non-iterable objects')
+
+    def next(self):
+        if self.closed:
+            raise ValueError()
+        try:
+            if self.iterable:
+                return next(self.data_src)
+            else:
+                if self.amt_read == self.length:
+                    raise StopIteration
+                ret = self.data_src.read(self.read_chunk)
+                self.amt_read += len(ret)
+                if not ret:
+                    raise StopIteration
+                return ret
+        except Exception as e:
+            if type(e) != StopIteration:
+                # Likely, a partial read
+                self.close_data()
+            self.closed = True
+            self.resource.close()
+            self.exhausted = True
+            raise
+
+    def __next__(self):
+        return self.next()
+
+    def __iter__(self):
+        return self
+
+    def __del__(self):
+        """
+            There could be an exception raised, the resource is not put back in
+            the pool, and the content is not consumed. We handle this in the
+            destructor.
+        """
+        if not self.exhausted:
+            self.close_data()
+        if not self.closed:
+            self.resource.close()
+
+
 def convert_to_s3_headers(swift_headers):
     s3_headers = {}
     for hdr in swift_headers.keys():


### PR DESCRIPTION
When handling GET requests through the shunt, we should make sure the
body is consumed before returning the connection to the pool. This
means that we cannot use the context manager without turning the
get_object() function into a generator. The patch adds a wrapper
around the body that returns the connection to the pool after the body
is fully consumed (or the object is destroyed).