### PR TITLE
Add poll_interval to swift-s3-migrator

### DIFF
--- a/test/container/launch.sh
+++ b/test/container/launch.sh
@@ -46,6 +46,8 @@ cd /swift-s3-sync; pip install -e .
 
 python -m s3_sync --log-level debug \
     --config /swift-s3-sync/test/container/swift-s3-sync.conf &
+swift-s3-migrator --log-level debug \
+    --config /swift-s3-sync/test/container/swift-s3-sync.conf &
 
 /bin/bash /s3proxy/s3proxy \
     --properties /swift-s3-sync/test/container/s3proxy.properties \

--- a/test/container/swift-s3-sync.conf
+++ b/test/container/swift-s3-sync.conf
@@ -75,10 +75,19 @@
             "restore_object": true
         }
     ],
+    "migrations": [],
+    "migrator_settings": {
+        "items_chunk": 1000,
+        "log_file": "/var/log/swift-s3-migrator.log",
+        "poll_interval": 1,
+        "status_file": "/var/lib/swift-s3-sync/migrator.status",
+        "workers": 10,
+        "processes": 1,
+        "process": 0
+    },
     "devices": "/swift/nodes/1/node",
     "items_chunk": 1000,
     "log_file": "/var/log/swift-s3-sync.log",
-    "log_level": "debug",
     "poll_interval": 1,
     "status_dir": "/var/lib/swift-s3-sync",
     "workers": 10

--- a/test/unit/test_migrator.py
+++ b/test/unit/test_migrator.py
@@ -13,6 +13,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import time
+import mock
+import logging
+from StringIO import StringIO
+from contextlib import contextmanager
 
 import s3_sync.migrator
 import unittest
@@ -90,3 +95,63 @@ class TestMigrator(unittest.TestCase):
             else:
                 with self.assertRaises(expected):
                     s3_sync.migrator.cmp_object_entries(left, right)
+
+
+class TestMain(unittest.TestCase):
+
+    def setUp(self):
+        self.logger = logging.getLogger()
+        self.stream = StringIO()
+        self.logger.addHandler(logging.StreamHandler(self.stream))
+        self.conf = {
+            'migrations': [],
+            'migration_status': None,
+            'internal_pool': None,
+            'logger': self.logger,
+            'items_chunk': None,
+            'node_id': 0,
+            'nodes': 1,
+            'poll_interval': 30,
+            'once': True,
+        }
+
+    @contextmanager
+    def patch(self, name):
+        with mock.patch('s3_sync.migrator.' + name) as mocked:
+            yield mocked
+
+    def pop_log_lines(self):
+        lines = self.stream.getvalue()
+        self.stream.seek(0)
+        self.stream.truncate()
+        return lines
+
+    def test_run_once(self):
+        start = time.time()
+        with self.patch('time') as mocktime:
+            mocktime.time.side_effect = [start, start + 1]
+            s3_sync.migrator.run(**self.conf)
+            # with once = True we don't sleep
+            self.assertEqual(mocktime.sleep.call_args_list, [])
+            self.assertEqual('Finished cycle in 1.00s\n',
+                             self.pop_log_lines())
+
+    def test_run_forever(self):
+        start = time.time()
+        self.conf['once'] = False
+
+        class StopDeamon(Exception):
+            pass
+
+        with self.patch('process_migrations') as mock_process, \
+                self.patch('time') as mocktime:
+            mock_process.side_effect = [None, None, StopDeamon()]
+            mocktime.time.side_effect = [start + i for i in range(5)]
+            with self.assertRaises(StopDeamon):
+                s3_sync.migrator.run(**self.conf)
+            self.assertEqual(mocktime.sleep.call_args_list,
+                             [mock.call(29)] * 2)
+            self.assertEqual([
+                'Finished cycle in 1.00s, sleeping for 29.00s.',
+                'Finished cycle in 1.00s, sleeping for 29.00s.',
+            ], self.pop_log_lines().splitlines())


### PR DESCRIPTION
By default we'll cycle at most once every five seconds, you can
configure the poll_interval in the migration_settings section of the
json config.