### PR TITLE
Shunt bimodal accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ pip install swift-s3-sync-<version>.tar.gz
 
 You also will need to install the `container-crawler` library from Git:
 ```
-pip install -e git://github.com/swiftstack/container-crawler.git@0.0.11#egg=container-crawler
+pip install -e git://github.com/swiftstack/container-crawler.git@0.0.12#egg=container-crawler
 ```
 
 After that, you should have the `swift-s3-sync` executable available in

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3==1.3.1
 -e git://github.com/swiftstack/botocore.git@1.4.32.6#egg=botocore
--e git://github.com/swiftstack/container-crawler.git@0.0.11#egg=container-crawler
+-e git://github.com/swiftstack/container-crawler.git@0.0.12#egg=container-crawler

--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -28,7 +28,7 @@ from swift.proxy.controllers.base import get_account_info
 
 from .provider_factory import create_provider
 from .utils import (check_slo, SwiftPutWrapper, SwiftSloPutWrapper,
-                    convert_to_local_headers)
+                    convert_to_local_headers, response_is_complete)
 
 
 class S3SyncProxyFSSwitch(object):
@@ -233,7 +233,7 @@ class S3SyncShunt(object):
             status_code, headers, app_iter = provider.shunt_object(req, obj)
             put_headers = convert_to_local_headers(headers)
 
-            if status_code == 200:
+            if response_is_complete(status_code, headers):
                 if check_slo(put_headers) and manifest:
                     app_iter = SwiftSloPutWrapper(
                         app_iter, put_headers, req.environ['PATH_INFO'],

--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -58,6 +58,7 @@ class S3SyncProxyFSSwitch(object):
         return utils.config_true_value(account_info["sysmeta"].get(
             'proxyfs-bimodal'))
 
+
 class S3SyncShunt(object):
     def __init__(self, app, conf_file, conf):
         self.logger = utils.get_logger(

--- a/s3_sync/sync_container.py
+++ b/s3_sync/sync_container.py
@@ -27,7 +27,10 @@ import time
 
 import container_crawler.base_sync
 from .provider_factory import create_provider
-from container_crawler import RetryError
+from container_crawler import RetryError, SkipContainer
+
+
+PROXYFS_CHECKPOINT_CONTAINER = '.__checkpoint__'
 
 
 class SyncContainer(container_crawler.base_sync.BaseSync):
@@ -39,6 +42,8 @@ class SyncContainer(container_crawler.base_sync.BaseSync):
 
     def __init__(self, status_dir, sync_settings, max_conns=10,
                  per_account=False):
+        if sync_settings['container'] == PROXYFS_CHECKPOINT_CONTAINER:
+            raise SkipContainer
         super(SyncContainer, self).__init__(
             status_dir, sync_settings, per_account)
         self.logger = logging.getLogger('s3-sync')

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -358,6 +358,8 @@ class SyncSwift(BaseSync):
                 headers, body = client.client.get_object(
                     bucket, key,
                     query_string='multipart-manifest=get')
+                if 'x-static-large-object' not in headers:
+                    return None
                 return json.loads(body)
             except Exception as e:
                 self.logger.warning('Failed to fetch the manifest: %s' % e)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='swift-s3-sync',
       packages=['s3_sync'],
       dependency_links=[
           'git://github.com/swiftstack/botocore.git@1.4.32.6#egg=botocore',
-          'git://github.com/swiftstack/container-crawler.git@0.0.11'
+          'git://github.com/swiftstack/container-crawler.git@0.0.12'
           '#egg=container-crawler',
       ],
       install_requires=['boto3==1.3.1'],

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
 
 RUN pip install -e git://github.com/swiftstack/botocore.git@1.4.32.6#egg=botocore && \
     pip install boto3==1.3.1 && \
-    pip install -e git://github.com/swiftstack/container-crawler.git@0.0.11#egg=container-crawler && \
+    pip install -e git://github.com/swiftstack/container-crawler.git@0.0.12#egg=container-crawler && \
     pip install nose flake8==3.5.0 && \
     pip uninstall -y hacking
 

--- a/test/unit/test_shunt.py
+++ b/test/unit/test_shunt.py
@@ -145,25 +145,25 @@ class TestShunt(unittest.TestCase):
 
     def test_bad_config_noops(self):
         app = shunt.filter_factory(
-            {'conf_file': '/etc/doesnt/exist'})(FakeSwift())
+            {'conf_file': '/etc/doesnt/exist'})(FakeSwift()).shunted_app
         self.assertEqual(app.sync_profiles, {})
 
         with tempfile.NamedTemporaryFile() as fp:
             # empty
             app = shunt.filter_factory(
-                {'conf_file': fp.name})(FakeSwift())
+                {'conf_file': fp.name})(FakeSwift()).shunted_app
             self.assertEqual(app.sync_profiles, {})
 
             # not json
             fp.write('{"containers":')
             fp.flush()
             app = shunt.filter_factory(
-                {'conf_file': fp.name})(FakeSwift())
+                {'conf_file': fp.name})(FakeSwift()).shunted_app
             self.assertEqual(app.sync_profiles, {})
 
     def test_init(self):
         self.maxDiff = None
-        self.assertEqual(self.app.sync_profiles, {
+        self.assertEqual(self.app.shunted_app.sync_profiles, {
             ('AUTH_a', 'sw\xc3\xa9ft'): {
                 'account': 'AUTH_a',
                 'container': 'sw\xc3\xa9ft'.decode('utf-8'),
@@ -372,6 +372,7 @@ class TestShunt(unittest.TestCase):
                     [(e['REQUEST_METHOD'], e['PATH_INFO'])
                      for e in self.swift.calls],
                     [
+                        ('HEAD', '/v1/%s' % account),
                         ('GET', '/v1/%s/foo' % path),
                     ])
             elif is_slo:
@@ -379,6 +380,7 @@ class TestShunt(unittest.TestCase):
                     [(e['REQUEST_METHOD'], e['PATH_INFO'])
                      for e in self.swift.calls],
                     [
+                        ('HEAD', '/v1/%s' % account),
                         ('GET', '/v1/%s/foo' % path),
                         ('PUT', '/v1/%s/segments' % account),
                         ('PUT', '/v1/%s/segments/part1' % account),
@@ -391,6 +393,7 @@ class TestShunt(unittest.TestCase):
                     [(e['REQUEST_METHOD'], e['PATH_INFO'])
                      for e in self.swift.calls],
                     [
+                        ('HEAD', '/v1/%s' % account),
                         ('GET', '/v1/%s/foo' % path),
                         ('PUT', '/v1/%s/foo' % path),
                     ])

--- a/test/unit/test_shunt.py
+++ b/test/unit/test_shunt.py
@@ -135,8 +135,9 @@ class TestShunt(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as fp:
             json.dump(self.conf, fp)
             fp.flush()
+            self.swift = FakeSwift()
             self.app = shunt.filter_factory(
-                {'conf_file': fp.name})(FakeSwift())
+                {'conf_file': fp.name})(self.swift)
 
     def tearDown(self):
         for patcher in self.patchers:
@@ -363,43 +364,39 @@ class TestShunt(unittest.TestCase):
             mock_call.return_value = resp
             req = swob.Request.blank(u'/v1/%s/foo' % path, environ=env)
             status, headers, body_iter = req.call_application(self.app)
-            resp_body = ''
-            while True:
-                data = body_iter.read()
-                if not data:
-                    break
-                resp_body += data
+            resp_body = b''.join(body_iter)
+            path = path.encode('utf-8')
+            account = path.split('/', 1)[0]
             if not is_put_back:
-                self.assertEqual(1, len(self.app.app.calls))
+                self.assertEqual(
+                    [(e['REQUEST_METHOD'], e['PATH_INFO'])
+                     for e in self.swift.calls],
+                    [
+                        ('GET', '/v1/%s/foo' % path),
+                    ])
             elif is_slo:
-                self.assertEqual(4, len(self.app.app.calls))
                 self.assertEqual(
-                    'PUT', self.app.app.calls[1]['REQUEST_METHOD'])
-                account = path.split('/', 1)[0]
-                self.assertEqual((u'/v1/%s/segments' % account),
-                                 self.app.app.calls[1]['PATH_INFO'])
-                self.assertEqual(
-                    'PUT', self.app.app.calls[2]['REQUEST_METHOD'])
-                self.assertEqual((u'/v1/%s/segments/part1' % account),
-                                 self.app.app.calls[2]['PATH_INFO'])
-                self.assertEqual(
-                    'PUT', self.app.app.calls[3]['REQUEST_METHOD'])
-                self.assertEqual((u'/v1/%s/foo' % path).encode('utf-8'),
-                                 self.app.app.calls[3]['PATH_INFO'])
+                    [(e['REQUEST_METHOD'], e['PATH_INFO'])
+                     for e in self.swift.calls],
+                    [
+                        ('GET', '/v1/%s/foo' % path),
+                        ('PUT', '/v1/%s/segments' % account),
+                        ('PUT', '/v1/%s/segments/part1' % account),
+                        ('PUT', '/v1/%s/foo' % path),
+                    ])
                 self.assertEqual('multipart-manifest=put',
-                                 self.app.app.calls[3]['QUERY_STRING'])
+                                 self.swift.calls[-1]['QUERY_STRING'])
             else:
-                self.assertEqual(2, len(self.app.app.calls))
                 self.assertEqual(
-                    'PUT', self.app.app.calls[1]['REQUEST_METHOD'])
-                self.assertEqual((u'/v1/%s/foo' % path).encode('utf-8'),
-                                 self.app.app.calls[1]['PATH_INFO'])
-            self.assertEqual('GET', self.app.app.calls[0]['REQUEST_METHOD'])
-            self.assertEqual((u'/v1/%s/foo' % path).encode('utf-8'),
-                             self.app.app.calls[0]['PATH_INFO'])
+                    [(e['REQUEST_METHOD'], e['PATH_INFO'])
+                     for e in self.swift.calls],
+                    [
+                        ('GET', '/v1/%s/foo' % path),
+                        ('PUT', '/v1/%s/foo' % path),
+                    ])
             self.assertEqual(payload, resp_body)
             mock_call.reset_mock()
-            self.app.app.calls = []
+            self.swift.calls = []
 
     def test_list_container_no_shunt(self):
         req = swob.Request.blank(

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -46,6 +46,25 @@ class TestUtilsFunctions(unittest.TestCase):
         expected_tag = 'ce7989f0e2f1f3e4fdd2a01dda0844ae-2'
         self.assertEqual(expected_tag, utils.get_slo_etag(sample_manifest))
 
+    def test_response_is_complete(self):
+        def do_test(status, headers):
+            self.assertTrue(utils.response_is_complete(status, headers))
+
+        do_test(200, [('any', 'headers')])
+        do_test(206, [('Content-Range', 'bytes 0-1/2')])
+        do_test(206, [('Content-Range', 'bytes 0-1000/1001')])
+
+        def do_test(status, headers):
+            self.assertFalse(utils.response_is_complete(status, headers))
+
+        do_test(206, [('Content-Range', 'some random crap')])
+        do_test(206, [('Content-Range', 'bytes 1-1000/1001')])
+        do_test(206, [('Content-Range', 'bytes 0-1000/1100')])
+        do_test(206, [('Content-Range', 'bytes 0-1000/*')])
+        do_test(206, [('Content-Range', 'bytes 0-wat/999')])
+        do_test(206, [('no', 'Content-Range')])
+        do_test(500, [('Content-Range', 'bytes 0-1000/1001')])
+
 
 class FakeSwift(object):
     def __init__(self):


### PR DESCRIPTION
Be able to archive ProxyFS data to a remote cloud. Presumably sync will also work, though its utility is questionable.

Since we walk container listings to find data that needs moving, we store the actual log segment data in the remote cloud (as opposed to a snapshot of the current file hierarchy). This requires that the shunt middleware be placed *after* the pfs middleware. However, we *also* have special handling around static large objects that requires the shunt be placed *before* slo -- resolve this by introducing a new config option (`handle_proxyfs`) and updating the proxy-server config to something like

```
[pipeline:main]
pipeline = ... cloud_shunt ... slo ... pfs pfs_cloud_shunt ... proxy-server

...

[filter:cloud_shunt]
use = egg:swift-s3-sync#cloud-shunt
conf_file = ...
handle_proxyfs = false

[filter:pfs_cloud_shunt]
use = egg:swift-s3-sync#cloud-shunt
conf_file = ...
handle_proxyfs = true
```

The no-auth pipeline used by proxyfsd will also need to be updated; FWIW, I'm running:

```
[pipeline:main]
pipeline = catch_errors gatekeeper healthcheck proxy-logging cache copy dlo meta pfs_cloud_shunt versioned_writes proxy-logging proxy-server

...

[filter:pfs_cloud_shunt]
use = egg:swift-s3-sync#cloud-shunt
conf_file = ...
handle_proxyfs = true
```

(I'm *pretty* sure we want to be after `meta`?)

**Note**: *only* log segment data should be archived -- checkpoint data we want to stay local.

Requires https://github.com/swiftstack/ProxyFS/pull/74 to prevent the sync daemon from thinking that a log segment containing an SLO manifest needs to have its segments synced. (They'd all 404.)

Requires https://github.com/swiftstack/container-crawler/pull/6 to allow us to skip `.__checkpoint__` containers.

Probably also requires https://github.com/swiftstack/ProxyFS/pull/72 ?