### PR TITLE
Migrate container ACLs in Swift->Swift configurations

### DIFF
--- a/test/container/swift-s3-sync.conf
+++ b/test/container/swift-s3-sync.conf
@@ -93,6 +93,15 @@
             "aws_secret": "testing2",
             "container": "migration-swift",
             "protocol": "swift"
+        },
+        {
+            "account": "AUTH_test",
+            "aws_bucket": "no-auto-acl",
+            "aws_endpoint": "http://localhost:8080/auth/v1.0",
+            "aws_identity": "test2:tester2",
+            "aws_secret": "testing2",
+            "container": "no-auto-acl",
+            "protocol": "swift"
         }
     ],
     "migrator_settings": {

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -26,9 +26,19 @@ import unittest
 
 
 def clear_swift_container(client, container):
-    _, list_results = client.get_container(container)
+    try:
+        _, list_results = client.get_container(container)
+    except swiftclient.exceptions.ClientException as e:
+        if e.http_status == 404:
+            return
+        raise
     for obj in list_results:
-        client.delete_object(container, obj['name'])
+        try:
+            client.delete_object(container, obj['name'])
+        except swiftclient.exceptions.ClientException as e:
+            if e.http_status == 404:
+                continue
+            raise
 
 
 def clear_s3_bucket(client, bucket):
@@ -152,6 +162,8 @@ class TestCloudSyncBase(unittest.TestCase):
 
         for container in \
                 self.test_conf['containers'] + self.test_conf['migrations']:
+            if container['container'].startswith('no-auto-'):
+                continue
             if container['protocol'] == 'swift':
                 self.swift_dst.put_container(container['aws_bucket'])
             else:
@@ -167,7 +179,9 @@ class TestCloudSyncBase(unittest.TestCase):
     def tearDownClass(self):
         if 'NO_TEARDOWN' in os.environ:
             return
-        for container in self.test_conf['containers']:
+        all_containers = self.test_conf['containers'] + \
+            self.test_conf['migrations']
+        for container in all_containers:
             if container['protocol'] == 'swift':
                 self._remove_swift_container(
                     self.swift_dst, container['aws_bucket'])
@@ -179,7 +193,7 @@ class TestCloudSyncBase(unittest.TestCase):
                         continue
                 self.s3_client.delete_bucket(Bucket=container['aws_bucket'])
 
-        for container in self.test_conf['containers']:
+        for container in all_containers:
             self._remove_swift_container(
                 self.swift_src, container['container'])
 
@@ -196,7 +210,11 @@ class TestCloudSyncBase(unittest.TestCase):
     @staticmethod
     def _remove_swift_container(client, container):
         clear_swift_container(client, container)
-        client.delete_container(container)
+        try:
+            client.delete_container(container)
+        except swiftclient.exceptions.ClientException as e:
+            if e.http_status == 404:
+                return
 
     def local_swift(self, method, *args, **kwargs):
         return getattr(self.swift_src, method)(*args, **kwargs)

--- a/test/integration/test_migrator.py
+++ b/test/integration/test_migrator.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 import StringIO
+import swiftclient
+import urllib
 from . import (TestCloudSyncBase, clear_swift_container, clear_s3_bucket,
                wait_for_condition)
 
@@ -106,3 +108,38 @@ class TestMigrator(TestCloudSyncBase):
 
         clear_swift_container(self.swift_dst, migration['aws_bucket'])
         clear_swift_container(self.swift_src, migration['container'])
+
+    def test_container_meta(self):
+        migration = self._find_migration(
+            lambda cont: cont['container'] == 'no-auto-acl')
+
+        self.remote_swift('put_container', migration['aws_bucket'],
+                          headers={'x-container-read': 'AUTH_test2',
+                                   'x-container-write': 'AUTH_test2',
+                                   'x-container-meta-test': 'test metadata'})
+
+        def _check_container_created():
+            try:
+                return self.local_swift(
+                    'get_container', migration['container'])
+            except swiftclient.exceptions.ClientException as e:
+                if e.http_status == 404:
+                    return False
+                raise
+
+        hdrs, listing = wait_for_condition(5, _check_container_created)
+        self.assertIn('x-container-meta-test', hdrs)
+        self.assertEqual('test metadata', hdrs['x-container-meta-test'])
+
+        scheme, rest = self.SWIFT_CREDS['authurl'].split(':', 1)
+        swift_host, _ = urllib.splithost(rest)
+
+        remote_swift = swiftclient.client.Connection(
+            authurl=self.SWIFT_CREDS['authurl'],
+            user=self.SWIFT_CREDS['dst']['user'],
+            key=self.SWIFT_CREDS['dst']['key'],
+            os_options={'object_storage_url': '%s://%s/v1/AUTH_test' % (
+                scheme, swift_host)})
+        remote_swift.put_object(migration['container'], 'test', 'test')
+        hdrs, body = remote_swift.get_object(migration['container'], 'test')
+        self.assertEqual(body, 'test')


### PR DESCRIPTION
Aside from just metadata, we should also propagate container ACLs during the migration.