### PR TITLE
Do not double release a connection semaphore.

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -54,6 +54,10 @@ class BaseSync(object):
             return self.semaphore.acquire(blocking=False)
 
         def close(self):
+            if self.semaphore.balance > BaseSync.HTTP_CONN_POOL_SIZE - 1:
+                logging.getLogger('s3-sync').error(
+                    'Detected double release of the semaphore')
+                raise RuntimeError('Detected double release of the semaphore!')
             self.semaphore.release()
             self.pool.release()
 

--- a/s3_sync/migrator.py
+++ b/s3_sync/migrator.py
@@ -385,6 +385,7 @@ class Migrator(object):
             args['resp_chunk_size'] = 65536
         resp = self.provider.get_object(key, **args)
         if resp.status != 200:
+            resp.body.close()
             raise MigrationError('Failed to GET %s/%s: %s' % (
                 container, key, resp.body))
         put_headers = convert_to_local_headers(

--- a/s3_sync/utils.py
+++ b/s3_sync/utils.py
@@ -447,6 +447,7 @@ class ClosingResourceIterable(object):
         if not self.exhausted:
             self.close_data()
         if not self.closed:
+            self.closed = True
             self.resource.close()
 
     def __next__(self):


### PR DESCRIPTION
If we double release the connection semaphore, the semaphore count goes
to 2, resulting in the connection being available to be checked out
twice. This can lead to data corruption, as multiple co-routines may be
using the same connection.

The patch adds some tests and a check for the semaphore balance before
calling release to try to detect such bugs.