### PR TITLE
Close connections after each Migrator pass.

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -173,6 +173,12 @@ class BaseSync(object):
     def list_buckets(self):
         raise NotImplementedError()
 
+    def close(self):
+        for client in self.client_pool.client_pool:
+            client.acquire()
+            self._close_conn(client.client)
+            client.close()
+
     def _get_client_factory(self):
         raise NotImplementedError()
 

--- a/s3_sync/migrator.py
+++ b/s3_sync/migrator.py
@@ -216,6 +216,7 @@ class Migrator(object):
         self.logger = logger
         self.node_id = node_id
         self.nodes = nodes
+        self.provider = None
 
     def next_pass(self):
         if self.config['aws_bucket'] != '/*':
@@ -484,6 +485,12 @@ class Migrator(object):
             finally:
                 self.object_queue.task_done()
 
+    def close(self):
+        if not self.provider:
+            return
+        self.provider.close()
+        self.provider = None
+
 
 def process_migrations(migrations, migration_status, internal_pool, logger,
                        items_chunk, node_id, nodes):
@@ -502,6 +509,7 @@ def process_migrations(migrations, migration_status, internal_pool, logger,
                                     internal_pool, logger,
                                     node_id, nodes)
                 migrator.next_pass()
+                migrator.close()
             except Exception as e:
                 logger.error('Migration error: %r\n%s' % (
                     e, traceback.format_exc(e)))

--- a/s3_sync/sync_s3.py
+++ b/s3_sync/sync_s3.py
@@ -91,6 +91,11 @@ class SyncS3(BaseSync):
             return s3_client
         return boto_client_factory
 
+    @staticmethod
+    def _close_conn(conn):
+        if conn._endpoint and conn._endpoint.http_session:
+            conn._endpoint.http_session.close()
+
     def upload_object(self, swift_key, storage_policy_index, internal_client):
         s3_key = self.get_s3_name(swift_key)
         try:

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -65,6 +65,11 @@ class SyncSwift(BaseSync):
                 os_options=os_options)
         return swift_client_factory
 
+    @staticmethod
+    def _close_conn(conn):
+        if conn.http_conn:
+            conn.http_conn[1].request_session.close()
+
     def upload_object(self, name, policy, internal_client):
         if self._per_account and not self.verified_container:
             with self.client_pool.get_client() as swift_client:


### PR DESCRIPTION
After each pass of the Migrator, we should close connections to the
remote cluster. Otherwise, we rely on HTTP timeouts, which can take
minutes, while creating more connections on each pass. This comes up
most acutely during tests, where the migrator can exhause the Swift
all-in-one connection pools on the proxy server.