### PR TITLE
Use the ResponseMetadata for status codes from S3.

### DIFF
--- a/s3_sync/sync_s3.py
+++ b/s3_sync/sync_s3.py
@@ -331,7 +331,8 @@ class SyncS3(BaseSync):
                     keys + prefixes,
                     key=lambda x: x['name'] if 'name' in x else x['subdir']))
         except botocore.exceptions.ClientError as e:
-            return (e.response['Error']['Code'], e.message)
+            return (e.response['ResponseMetadata']['HTTPStatusCode'],
+                    e.message)
 
     def upload_slo(self, swift_key, storage_policy_index, s3_meta,
                    internal_client):

--- a/test/unit/test_sync_s3.py
+++ b/test/unit/test_sync_s3.py
@@ -1357,7 +1357,8 @@ class TestSyncS3(unittest.TestCase):
 
     def test_list_objects_error(self):
         self.mock_boto3_client.list_objects.side_effect = ClientError(
-            dict(Error=dict(Code=500)), 'failed to list!')
+            dict(Error=dict(Code='ServerError'),
+                 ResponseMetadata=dict(HTTPStatusCode=500)), 'failed to list!')
         prefix = '%s/%s/%s/' % (self.sync_s3.get_prefix(),
                                 self.sync_s3.account, self.sync_s3.container)
 


### PR DESCRIPTION
The Error dictionary from S3 does not contain the HTTP status code. We
already use the ResponseMetadata from boto3 in all places and should do
so in list_objects, as well.