### PR TITLE
Migrator: The metadata ETag check is backwards.

### DIFF
--- a/s3_sync/migrator.py
+++ b/s3_sync/migrator.py
@@ -78,7 +78,7 @@ def cmp_object_entries(left, right):
 def cmp_meta(dest, source):
     if source['last-modified'] == dest['last-modified']:
         return EQUAL
-    if source['etag'] == dest['etag']:
+    if source['etag'] != dest['etag']:
         return ETAG_DIFF
     return TIME_DIFF
 

--- a/test/unit/test_migrator.py
+++ b/test/unit/test_migrator.py
@@ -538,6 +538,27 @@ class TestMigratorUtils(unittest.TestCase):
         status.load_status_list()
         self.assertEqual(status_list, status.status_list)
 
+    def test_cmp_meta(self):
+        test_cases = [
+            ({'last-modified': create_timestamp(1.5e9),
+              'etag': 'foo'},
+             {'last-modified': create_timestamp(1.5e9),
+              'etag': 'bar'},
+             s3_sync.migrator.EQUAL),
+            ({'last-modified': create_timestamp(1.5e9),
+              'etag': 'foo'},
+             {'last-modified': create_timestamp(1.4e9),
+              'etag': 'bar'},
+             s3_sync.migrator.ETAG_DIFF),
+            ({'last-modified': create_timestamp(1.5e9),
+              'etag': 'foo'},
+             {'last-modified': create_timestamp(1.4e9),
+              'etag': 'foo'},
+             s3_sync.migrator.TIME_DIFF)
+        ]
+        for left, right, expected in test_cases:
+            self.assertEqual(expected, s3_sync.migrator.cmp_meta(left, right))
+
 
 class TestMigrator(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes the ETag check, along with a unit test.