### PR TITLE
Migrator: a specific error for missing containers.

### DIFF
--- a/test/unit/test_migrator.py
+++ b/test/unit/test_migrator.py
@@ -1007,8 +1007,8 @@ class TestMigrator(unittest.TestCase):
         self.migrator.status.get_migration.return_value = {}
 
         self.migrator.next_pass()
-        self.assertEqual('MigrationError: Failed to HEAD bucket/container '
-                         '"bucket"', self.get_log_lines()[-1])
+        self.assertEqual('Bucket/container "bucket" does not exist',
+                         self.get_log_lines()[0])
         provider.head_bucket.assert_called_once_with(
             self.migrator.config['container'])
 


### PR DESCRIPTION
When a container is missing, we can do better than logging a generic
MigrationError. This helps reduce tracebacks and improves the
readability of the log.