### PR TITLE
Initial cleanup/refactoring for cloud-connector

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -146,28 +146,28 @@ class BaseSync(object):
             self.aws_bucket,
         )
 
-    def upload_object(self, name, storage_policy_index):
+    def upload_object(self, swift_key, storage_policy_index, internal_client):
         raise NotImplementedError()
 
     def update_metadata(self, swift_key, swift_meta):
         raise NotImplementedError()
 
-    def delete_object(self, name):
+    def delete_object(self, swift_key):
         raise NotImplementedError()
 
-    def shunt_object(self, request, name):
+    def shunt_object(self, request, swift_key):
         raise NotImplementedError()
 
-    def get_object(self, key, bucket=None, **options):
+    def head_object(self, swift_key, bucket=None, **options):
         raise NotImplementedError()
 
-    def head_object(self, key, bucket=None, **options):
+    def get_object(self, swift_key, bucket=None, **options):
         raise NotImplementedError()
 
     def head_bucket(self, bucket, **options):
         raise NotImplementedError()
 
-    def list_objects(self, marker, limit, prefix, delimiter=None):
+    def list_objects(self, marker, limit, prefix, delimiter=None, bucket=None):
         raise NotImplementedError()
 
     def list_buckets(self):

--- a/s3_sync/sync_container.py
+++ b/s3_sync/sync_container.py
@@ -108,7 +108,7 @@ class SyncContainer(container_crawler.base_sync.BaseSync):
     def handle(self, row, swift_client):
         if row['deleted']:
             if self.propagate_delete:
-                self.provider.delete_object(row['name'], swift_client)
+                self.provider.delete_object(row['name'])
         else:
             # The metadata timestamp should always be the latest timestamp
             _, _, meta_ts = decode_timestamps(row['created_at'])

--- a/s3_sync/utils.py
+++ b/s3_sync/utils.py
@@ -30,6 +30,18 @@ MANIFEST_HEADER = 'x-object-manifest'
 SLO_HEADER = 'x-static-large-object'
 SLO_ETAG_FIELD = 'swift-slo-etag'
 SWIFT_TIME_FMT = '%Y-%m-%dT%H:%M:%S.%f'
+# Blacklist of known hop-by-hop headers taken from
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers
+HOP_BY_HOP_HEADERS = set([
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
+    'transfer-encoding',
+    'upgrade',
+])
 
 
 class FileWrapper(object):
@@ -463,6 +475,13 @@ class ClosingResourceIterable(object):
             destructor.
         """
         self.close()
+
+
+def filter_hop_by_hop_headers(headers):
+    # Take an iterable of (key, value) tuples and return a list of (key, value)
+    # tuples with any hop-by-hop headers removed.
+    return [(k, v) for (k, v) in headers
+            if k.lower() not in HOP_BY_HOP_HEADERS]
 
 
 def convert_to_s3_headers(swift_headers):

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,7 +1,8 @@
 FROM bouncestorage/swift-aio:latest
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y python-support openjdk-7-jdk wget && \
+    apt-get install --no-install-recommends -y python-support openjdk-7-jdk \
+        wget curl && \
     apt-get clean
 
 RUN pip install -e git://github.com/swiftstack/botocore.git@1.4.32.6#egg=botocore && \

--- a/test/unit/test_sync_container.py
+++ b/test/unit/test_sync_container.py
@@ -425,5 +425,5 @@ class TestSyncContainer(unittest.TestCase):
         sync.handle(row, None)
 
         # Make sure that we do not make any additional calls
-        self.assertEqual([mock.call.delete_object(row['name'], None)],
+        self.assertEqual([mock.call.delete_object(row['name'])],
                          sync.provider.mock_calls)

--- a/test/unit/test_sync_s3.py
+++ b/test/unit/test_sync_s3.py
@@ -452,6 +452,19 @@ class TestSyncS3(unittest.TestCase):
                     'aws_endpoint': 'http://test.com'})
             conf_mock.assert_called_once_with(s3={'addressing_style': 'path'})
 
+    @mock.patch('s3_sync.sync_s3.boto3.session.Session')
+    def test_session_token_plumbing(self, session_mock):
+        SyncS3({'aws_bucket': 'a_bucket',
+                'aws_identity': 'an_identity',
+                'aws_secret': 'a_credential',
+                'aws_session_token': 'a_token',
+                'account': 'an_account',
+                'container': 'a_container'})
+        session_mock.assert_called_once_with(
+            aws_access_key_id='an_identity',
+            aws_secret_access_key='a_credential',
+            aws_session_token='a_token')
+
     def test_slo_upload(self):
         slo_key = 'slo-object'
         storage_policy = 42


### PR DESCRIPTION
Made method interfaces consistent between BaseSync abastract base class
and its children.

Pulled out `filter_hop_by_hop_headers` to utility file (cloud-connector
will want to use that).

Added plumbing in SyncS3.__init__() to take an AWS session token in the
settings (used when deploying containers to amazon ECS, when the
environment will have URL that responds with expiring, session-based
credentials).  In the cloud-connect use-case, the session is only used
once, so there's no provision for noticing credential expiration and
fetching new credentials from the URL.

Added `curl` to the integration test/development testing container,
since it's handy for manual testing.