### PR TITLE
Honor Container Specification for Migration

### DIFF
--- a/test/container/swift-s3-sync.conf
+++ b/test/container/swift-s3-sync.conf
@@ -96,6 +96,15 @@
         },
         {
             "account": "AUTH_test",
+            "aws_bucket": "migration-swift2",
+            "aws_endpoint": "http://localhost:8080/auth/v1.0",
+            "aws_identity": "test2:tester2",
+            "aws_secret": "testing2",
+            "container": "migration-swift-reloc",
+            "protocol": "swift"
+        },
+        {
+            "account": "AUTH_test",
             "aws_bucket": "no-auto-acl",
             "aws_endpoint": "http://localhost:8080/auth/v1.0",
             "aws_identity": "test2:tester2",


### PR DESCRIPTION
This will allow migration of a single container to a new location.

Notes:
 - SLO and DLO segment containers keep names across migration - no change for now
