### PR TITLE
Propagate POST and DELETE for Swift->Swift mappings.

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -158,6 +158,9 @@ class BaseSync(object):
     def shunt_object(self, request, swift_key):
         raise NotImplementedError()
 
+    def shunt_post(self, request, swift_key):
+        raise NotImplementedError()
+
     def shunt_delete(self, request, swift_key):
         raise NotImplementedError()
 

--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -158,6 +158,9 @@ class BaseSync(object):
     def shunt_object(self, request, swift_key):
         raise NotImplementedError()
 
+    def shunt_delete(self, request, swift_key):
+        raise NotImplementedError()
+
     def head_object(self, swift_key, bucket=None, **options):
         raise NotImplementedError()
 

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -203,6 +203,17 @@ class SyncSwift(BaseSync):
                              req.method)
         return resp.to_wsgi()
 
+    def shunt_delete(self, req, swift_key):
+        """Propagate metadata to the remote store
+
+         :returns: (status, headers, body_iter) tuple
+        """
+        headers = dict([(k, req.headers[k]) for k in req.headers.keys()
+                        if req.headers[k]])
+        resp = self._call_swiftclient(
+            'delete_object', self.remote_container, swift_key, headers=headers)
+        return resp.to_wsgi()
+
     def head_object(self, swift_key, bucket=None, **options):
         if bucket is None:
             bucket = self.remote_container
@@ -248,6 +259,9 @@ class SyncSwift(BaseSync):
                     resp = getattr(client, op)(container, **args)
                 else:
                     resp = getattr(client, op)(container, key, **args)
+                if not resp:
+                    return ProviderResponse(True, '204 No Content', {}, [''])
+
                 if isinstance(resp, tuple):
                     headers, body = resp
                 else:

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -203,6 +203,17 @@ class SyncSwift(BaseSync):
                              req.method)
         return resp.to_wsgi()
 
+    def shunt_post(self, req, swift_key):
+        """Propagate metadata to the remote store
+
+         :returns: (status, headers, body_iter) tuple
+        """
+        headers = dict([(k, req.headers[k]) for k in req.headers.keys()
+                        if req.headers[k]])
+        resp = self._call_swiftclient(
+            'post_object', self.remote_container, swift_key, headers=headers)
+        return resp.to_wsgi()
+
     def shunt_delete(self, req, swift_key):
         """Propagate metadata to the remote store
 

--- a/test/unit/test_shunt.py
+++ b/test/unit/test_shunt.py
@@ -244,6 +244,7 @@ class TestShunt(unittest.TestCase):
                 # Need a container key, or the provider balks. Migrations move
                 # data from one name to the same name, so crib from aws_bucket
                 'container': 'some-bucket',
+                'migration': True,
             },
             ('AUTH_all-their-containers', '/*'): {
                 'account': 'AUTH_all-their-containers',
@@ -255,6 +256,7 @@ class TestShunt(unittest.TestCase):
                 'remote_account': 'AUTH_all-my-containers',
                 'restore_object': True,
                 'container': '/*',
+                'migration': True,
             },
         })
 


### PR DESCRIPTION
Two commits that implement POST and DELETE propagation. There is a slight dependency between them, which is why I put them in the same PR.