### PR TITLE
We should preserve the ETag for Swift uploads.

### DIFF
--- a/test/integration/test_s3_sync.py
+++ b/test/integration/test_s3_sync.py
@@ -220,8 +220,12 @@ class TestCloudSync(TestCloudSyncBase):
             prefix, '.manifests', account, container,
             '%s.swift_slo_manifest' % (key_hash)])
         manifest = [
-            {'bytes': 5 * 1024 * 1024, 'name': '/segments/part1'},
-            {'bytes': 1024 * 1024, 'name': '/segments/part2'}]
+            {'bytes': 5 * 1024 * 1024,
+             'name': '/segments/part1',
+             'hash': hashlib.md5('A' * 5 * 2**20).hexdigest()},
+            {'bytes': 1024 * 1024,
+             'name': '/segments/part2',
+             'hash': hashlib.md5('A' * 2**20).hexdigest()}]
         self.s3('put_object',
                 Bucket=mapping['aws_bucket'],
                 Key=manifest_key,

--- a/test/unit/test_shunt.py
+++ b/test/unit/test_shunt.py
@@ -386,15 +386,16 @@ class TestShunt(unittest.TestCase):
             (u'AUTH_a/sw\u00e9ft',
              (200,
               [('Content-Length', len(payload)),
-               (utils.SLO_HEADER, 'True')],
+               (utils.SLO_HEADER, 'True'),
+               ('etag', 'etag')],
               StringIO.StringIO(payload)),
              mock_swift_shunt, True),
             ('AUTH_tee/tee',
-             (200, [('Content-Length', len(payload))],
+             (200, [('Content-Length', len(payload)), ('etag', 'etag')],
               StringIO.StringIO(payload)),
              mock_s3_shunt, True),
             (u'AUTH_a/sw\u00e9ft',
-             (200, [('Content-Length', len(payload))],
+             (200, [('Content-Length', len(payload)), ('etag', 'etag')],
               StringIO.StringIO(payload)),
              mock_swift_shunt, True)
         ]
@@ -408,7 +409,7 @@ class TestShunt(unittest.TestCase):
         }
 
         for path, resp, mock_call, is_put_back in responses:
-            if dict(resp[1]).get('etag', '').endswith('-2') or\
+            if dict(resp[1])['etag'].endswith('-2') or\
                     utils.SLO_HEADER in dict(resp[1]):
                 is_slo = True
             else:
@@ -416,7 +417,8 @@ class TestShunt(unittest.TestCase):
             if is_slo:
                 manifest = [{
                     'bytes': len(payload),
-                    'name': '/segments/part1'}]
+                    'name': '/segments/part1',
+                    'hash': 'etag'}]
                 mock_s3_get_manifest.return_value = manifest
                 mock_swift_get_manifest.return_value = manifest
             mock_call.return_value = resp

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -67,6 +67,24 @@ class TestUtilsFunctions(unittest.TestCase):
         do_test(206, [('no', 'Content-Range')])
         do_test(500, [('Content-Range', 'bytes 0-1000/1001')])
 
+    def test_convert_to_local_headers(self):
+        self.assertEqual({'content-type': 'application/test',
+                          'x-object-meta': 'object-meta',
+                          'etag': 'deadbeef'},
+                         utils.convert_to_local_headers(
+                         {'Remote-x-transaction-id': 'some id',
+                          'content-type': 'application/test',
+                          'x-timestamp': 12345,
+                          'x-object-meta': 'object-meta',
+                          'etag': 'deadbeef'}.items()))
+        self.assertEqual(
+            {'content-type': 'application/test', 'x-timestamp': 12345},
+            utils.convert_to_local_headers(
+                {'Remote-x-object-meta': 'foo',
+                 'x-timestamp': 12345,
+                 'content-type': 'application/test'}.items(),
+                remove_timestamp=False))
+
 
 class FakeSwift(object):
     def __init__(self):


### PR DESCRIPTION
When uploading objects into Swift, we used to replace the ETag header
with Content-MD5. As Swift ignores the Content-MD5, this is actually
wrong and we should rely on the ETag header.