### PR TITLE
Integration test helpers

### DIFF
--- a/test/integration/test_cloud_connector.py
+++ b/test/integration/test_cloud_connector.py
@@ -26,9 +26,6 @@ from s3_sync.provider_factory import create_provider
 
 
 class TestCloudConnector(TestCloudSyncBase):
-    def setUp(self):
-        super(TestCloudConnector, self).setUp()
-
     def test_auth(self):
         # A successful auth through cloud-connect should result in a cached
         # token => Swift Account mapping, as well as a token valid inside the
@@ -65,9 +62,9 @@ class TestCloudConnector(TestCloudSyncBase):
         self.assertEqual(404, cm.exception.http_status)
 
         # put the obj in swift
-        with self.admin_conn_for(mapping['account']) as admin_conn:
-            admin_conn.put_object(mapping['container'], 'foobie', 'abc',
-                                  headers={'x-object-meta-crazy': 'madness'})
+        admin_conn = self.conn_for_acct(mapping['account'])
+        admin_conn.put_object(mapping['container'], 'foobie', 'abc',
+                              headers={'x-object-meta-crazy': 'madness'})
 
         rheaders, body = self.cloud_connector('get_object',
                                               mapping['container'], 'foobie')
@@ -105,9 +102,9 @@ class TestCloudConnector(TestCloudSyncBase):
         self.assertEqual('3', rheaders['content-length'])
 
         # put a diff obj in real swift, should still get the S3 one back
-        with self.admin_conn_for(mapping['account']) as admin_conn:
-            admin_conn.put_object(mapping['container'], 'barbie', 'abcd',
-                                  headers={'x-object-meta-crazy': 'madness'})
+        admin_conn = self.conn_for_acct(mapping['account'])
+        admin_conn.put_object(mapping['container'], 'barbie', 'abcd',
+                              headers={'x-object-meta-crazy': 'madness'})
 
         rheaders, body = self.cloud_connector('get_object',
                                               mapping['container'], 'barbie')

--- a/test/integration/test_migrator.py
+++ b/test/integration/test_migrator.py
@@ -31,6 +31,11 @@ class TestMigrator(TestCloudSyncBase):
     def tearDown(self):
         # Make sure all migration-related containers are cleared
         for container in self.test_conf['migrations']:
+            if container.get('container'):
+                conn = self.conn_for_acct_noshunt(container['account'])
+                clear_swift_container(conn, container['container'])
+                clear_swift_container(conn,
+                                      container['container'] + '_segments')
             if container['aws_bucket'] == '/*':
                 continue
             if container['protocol'] == 'swift':
@@ -48,14 +53,6 @@ class TestMigrator(TestCloudSyncBase):
         # Clean out all container accounts
         clear_swift_account(self.swift_nuser)
         clear_swift_account(self.swift_nuser2)
-
-        for container in self.test_conf['migrations']:
-            if not container.get('container'):
-                continue
-            with self.admin_conn_for(container['account']) as conn:
-                clear_swift_container(conn, container['container'])
-                clear_swift_container(conn,
-                                      container['container'] + '_segments')
 
     def test_s3_migration(self):
         migration = self.s3_migration()


### PR DESCRIPTION
...for getting swiftclient.client.Connection() instances pointed at any
account, and going through the normal proxy, a noauth/noshunt proxy, or
the cloud-connector.

The good stuff is:
```
    @classmethod
    def conn_for_acct(klass, acct):
        ...

    @classmethod
    def conn_for_acct_noshunt(klass, acct):
        ...

    @classmethod
    def conn_for_acct_cc(klass, acct):
        ...

```
One conn per all accounts discovered during setup are stored in
```
    conn_by_acct = {}  # utf8_acct => Connection()
    conn_by_acct_noshunt = {}  # as above, but bypasses any shunt
    conn_by_acct_cc = {}  # as above, but through cloud-connector
```

So tearing down all objs in all containers in all accounts is as easy
as:
```
        for conn in klass.conn_by_acct_noshunt.values():
            clear_swift_account(conn)
```

A lot of the old stuff was left alone to minimize test disruption,
e.g.
```
        klass.swift_src = klass.conn_for_acct('AUTH_test')
        klass.swift_dst = klass.conn_for_acct(
            u"AUTH_\u062aacct2".encode('utf8'))
```