### PR TITLE
Fix Unicode bugs in migrator/shunt

### DIFF
--- a/run_bash
+++ b/run_bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# This will be fast if your bouncy is already up to date
+# This will be fast if your bouncestorage base image is already up to date in
+# your docker image library.
 docker pull bouncestorage/swift-aio
 # The --build is safe because if nothing in the Dockerfile has changed, it'll
 # just quickly "build" entirely from cache and not do anything.

--- a/s3_sync/migrator.py
+++ b/s3_sync/migrator.py
@@ -598,7 +598,7 @@ class Migrator(object):
             work = MigrateObjectWork(container, container, segment_key)
             self.object_queue.put(work)
         manifest_blob = json.dumps(manifest)
-        headers['Content-Length'] = len(manifest_blob)
+        headers['Content-Length'] = str(len(manifest_blob))
         work = UploadObjectWork(slo_container, key,
                                 FileLikeIter(manifest_blob), headers)
         self.object_queue.put(work)
@@ -613,6 +613,9 @@ class Migrator(object):
             ts = Timestamp((ts - EPOCH).total_seconds()).internal
             headers['x-timestamp'] = ts
         del headers['last-modified']
+        # Encode all headers as UTF8
+        headers = {k.encode('utf8'): v.encode('utf8')
+                   for k, v in headers.items()}
         with self.ic_pool.item() as ic:
             try:
                 ic.upload_object(

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -55,7 +55,8 @@ class SyncSwift(BaseSync):
         if self.settings.get('remote_account'):
             scheme, rest = endpoint.split(':', 1)
             host = urllib.splithost(rest)[0]
-            path = '/v1/%s' % urllib.quote(self.settings['remote_account'])
+            path = '/v1/%s' % urllib.quote(
+                self.settings['remote_account'].encode('utf8'))
             os_options = {
                 'object_storage_url': '%s:%s%s' % (scheme, host, path)}
 

--- a/s3_sync/utils.py
+++ b/s3_sync/utils.py
@@ -254,7 +254,7 @@ class SwiftPutWrapper(object):
         resp = self.put_thread.wait()
         if not resp.is_success and self.logger:
             self.logger.warning(
-                'Failed to restore the object: %d' % resp.status)
+                'Failed to restore the object: %s' % resp.status)
         close_if_possible(resp.app_iter)
         return resp
 

--- a/s3_sync/verify.py
+++ b/s3_sync/verify.py
@@ -94,15 +94,19 @@ def main(args=None):
     parser.add_argument('--account')
     parser.add_argument('--bucket')
     args = parser.parse_args(args)
+    # We normalize the conf to Unicode strings since that's how they come out
+    # of the JSON file.
     conf = {
         'protocol': args.protocol,
         'account': 'verify-auth',
         'container': u'testing-\U0001f44d',
         'aws_endpoint': args.endpoint,
-        'aws_identity': args.username,
-        'aws_secret': args.password,
-        'remote_account': args.account,
-        'aws_bucket': args.bucket,
+        'aws_identity': args.username.decode('utf8'),
+        'aws_secret': args.password.decode('utf8'),
+        'remote_account':
+        args.account.decode('utf8') if args.account else args.account,
+        'aws_bucket': args.bucket.decode('utf8') if args.bucket
+        else args.bucket,
     }
     if args.account and args.protocol != 'swift':
         return 'Invalid argument: account is only valid with swift protocol'

--- a/test/container/swift-s3-sync.conf
+++ b/test/container/swift-s3-sync.conf
@@ -212,6 +212,17 @@
             "aws_identity": "nacct:nuser",
             "aws_secret": "npass",
             "protocol": "swift"
+        },
+        {
+            "account": "AUTH_\u062aacct",
+            "aws_bucket": "flotty",
+            "aws_endpoint": "http://localhost:8080/auth/v1.0",
+            "aws_identity": "admin:admin",
+            "aws_secret": "admin",
+            "container": "flotty",
+            "prefix": "",
+            "protocol": "swift",
+            "remote_account": "AUTH_\u062aacct2"
         }
     ],
     "migrator_settings": {

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -283,9 +283,13 @@ class TestCloudSyncBase(unittest.TestCase):
 
             if mapping['protocol'] == 'swift':
                 # Get conns for the other side, too
-                conn_key = (mapping['aws_endpoint'], mapping['aws_identity'],
-                            mapping['aws_secret'])
-                acct_utf8 = url_user_key_to_acct.get(conn_key)
+                if mapping.get('remote_account'):
+                    acct_utf8 = mapping['remote_account'].encode('utf8')
+                else:
+                    conn_key = (mapping['aws_endpoint'],
+                                mapping['aws_identity'],
+                                mapping['aws_secret'])
+                    acct_utf8 = url_user_key_to_acct.get(conn_key)
                 if not acct_utf8:
                     # Need to auth to get acct name, then add it to the cache
                     conn = swiftclient.client.Connection(

--- a/test/unit/test_migrator.py
+++ b/test/unit/test_migrator.py
@@ -1063,12 +1063,12 @@ class TestMigrator(unittest.TestCase):
                 'remote_headers': {
                     'x-object-meta-custom': 'slo-meta',
                     'last-modified': create_timestamp(1.5e9),
-                    'x-static-large-object': True},
+                    'x-static-large-object': 'True'},
                 'expected_headers': {
                     'x-object-meta-custom': 'slo-meta',
                     'x-timestamp': Timestamp(1.5e9).internal,
-                    'x-static-large-object': True,
-                    'Content-Length': len(json.dumps(manifest))}
+                    'x-static-large-object': 'True',
+                    'Content-Length': str(len(json.dumps(manifest)))}
             },
             'part1': {
                 'remote_headers': {


### PR DESCRIPTION
The migrator wasn't encoding headers as UTF8 before sending them into
the InternalClient.

The shunt's SyncSwift provider wasn't encoding the `remote_account` into
UTF8 before using it to construct an overridden storage URL.

Fixed bouncy = bouncestorage misspelling.

Fixed setUpClass to get account name from `remote_account`, if present.

Fixed one existing migrator test to run UTF8 data (found first bug fixed
above, in the header handling).

Added new test for the bug I'm actually trying to fix, the 2nd bug
above.

Other migrator tests that were attempting to use Unicode data (but
aren't) can't be fixed until a different bug is fixed--that's currently
in progress by Mandell.