### PR TITLE
Shunt and migrator fixes for alternate destination container name in Migrations

### DIFF
--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -221,13 +221,9 @@ class S3SyncShunt(object):
             if rem_resp.status == 200:
                 status = '200 OK'
                 headers = {}
-                propagated_hdrs = ['x-container-read', 'x-container-write',
-                                   'x-history-location', 'x-versions-location']
                 for hdr in rem_resp.headers:
-                    if hdr.startswith('x-container-meta-') or\
-                            hdr in propagated_hdrs:
-                        headers[hdr.encode('utf8')] = \
-                            rem_resp.headers[hdr].encode('utf8')
+                    headers[hdr.encode('utf8')] = \
+                        rem_resp.headers[hdr].encode('utf8')
                 internal_resp = []
 
         if not status.startswith('200 '):

--- a/test/container/swift-s3-sync.conf
+++ b/test/container/swift-s3-sync.conf
@@ -186,7 +186,7 @@
             "aws_endpoint": "http://localhost:8080/auth/v1.0",
             "aws_identity": "\u062aacct2:\u062auser2",
             "aws_secret": "\u062apass2",
-            "container": "migration-swift-reloc",
+            "container": "no-auto-migration-swift-reloc",
             "protocol": "swift"
         },
         {

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -406,9 +406,6 @@ class TestCloudSyncBase(unittest.TestCase):
     def remote_swift(self, method, *args, **kwargs):
         return getattr(self.swift_dst, method)(*args, **kwargs)
 
-    def local_noshunt(self, method, *args, **kwargs):
-        return getattr(self.swift_noshunt, method)(*args, **kwargs)
-
     def cloud_connector(self, method, *args, **kwargs):
         return getattr(self.cloud_connector_client, method)(*args, **kwargs)
 

--- a/test/integration/test_s3_sync.py
+++ b/test/integration/test_s3_sync.py
@@ -19,7 +19,7 @@ import json
 import StringIO
 
 from . import TestCloudSyncBase, clear_swift_container, wait_for_condition, \
-    swift_content_location, s3_key_name, clear_s3_bucket
+    swift_content_location, s3_key_name, clear_s3_bucket, WaitTimedOut
 
 
 class TestCloudSync(TestCloudSyncBase):
@@ -75,7 +75,7 @@ class TestCloudSync(TestCloudSyncBase):
 
         try:
             wait_for_condition(5, _check_objs)
-        except RuntimeError:
+        except WaitTimedOut:
             pass
 
         self.assertEqual(['crazy-target:slashc1', 'crazy-target:slashc2',


### PR DESCRIPTION
    The migrator was looking for headers based on the destination_container from
    the source provider.
    
    [Fixes #156481586]
    [Fixes #156480264]

    Add container GET to shunt migration behavior
    
    If the container does not exist locally, display the remote container
    listing instead (if available).
    
    Also fixed up migration tests for specifying a different container and for
    metadata tests to make use of some of the new test infrastructure.
    
    [Fixes #156480670]
