### PR TITLE
Propagate DELETE container requests in migrations.

### DIFF
--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -142,8 +142,7 @@ class S3SyncShunt(object):
         sync_profile, per_account = maybe_munge_profile_for_all_containers(
             sync_profile, cont)
 
-        if obj and req.method == 'DELETE' and\
-                sync_profile.get('migration'):
+        if req.method == 'DELETE' and sync_profile.get('migration'):
             return self.handle_delete(
                 req, start_response, sync_profile, obj, per_account)
 

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -216,14 +216,20 @@ class SyncSwift(BaseSync):
         return resp.to_wsgi()
 
     def shunt_delete(self, req, swift_key):
-        """Propagate metadata to the remote store
+        """Propagate delete to the remote store
 
          :returns: (status, headers, body_iter) tuple
         """
         headers = dict([(k, req.headers[k]) for k in req.headers.keys()
                         if req.headers[k]])
-        resp = self._call_swiftclient(
-            'delete_object', self.remote_container, swift_key, headers=headers)
+        if not swift_key:
+            resp = self._call_swiftclient(
+                'delete_container', self.remote_container, None,
+                headers=headers)
+        else:
+            resp = self._call_swiftclient(
+                'delete_object', self.remote_container, swift_key,
+                headers=headers)
         return resp.to_wsgi()
 
     def head_object(self, swift_key, bucket=None, **options):


### PR DESCRIPTION
As we cannot set the X-Timestamp header when creating a container during
migrations, we have to make sure to propagate removal of containers to
the source cluster. As we don't do this currently, the containers will
be re-created on a subsequent migration run.

The commit also mutates the associated test to examine
the content_location information for the listings. This is necessary, as
after adding the support for migrations in the shunt we can no longer
simply examine the listing names.