### PR TITLE
Migrations: send container metadata to the source.

### DIFF
--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -153,7 +153,7 @@ class S3SyncShunt(object):
             # TODO: think about what to do for POST, COPY
             return self.handle_object(req, start_response, sync_profile, obj,
                                       per_account)
-        elif obj and req.method == 'POST':
+        elif req.method == 'POST':
             return self.handle_post(req, start_response, sync_profile, obj,
                                     per_account)
 
@@ -331,6 +331,10 @@ class S3SyncShunt(object):
 
         if sync_profile.get('protocol') != 'swift':
             # TODO: Add S3 support
+            start_response(status, headers)
+            return app_iter
+
+        if not obj and not sync_profile.get('migration'):
             start_response(status, headers)
             return app_iter
 

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -211,8 +211,13 @@ class SyncSwift(BaseSync):
         """
         headers = dict([(k, req.headers[k]) for k in req.headers.keys()
                         if req.headers[k]])
-        resp = self._call_swiftclient(
-            'post_object', self.remote_container, swift_key, headers=headers)
+        if swift_key:
+            resp = self._call_swiftclient(
+                'post_object', self.remote_container, swift_key,
+                headers=headers)
+        else:
+            resp = self._call_swiftclient(
+                'post_container', self.remote_container, None, headers=headers)
         return resp.to_wsgi()
 
     def shunt_delete(self, req, swift_key):


### PR DESCRIPTION
During a migration, a container may not have been yet created on the
destination cluster. At this time, if a POST request is made, we should
propagate it to the source cluster. Returning a not found error in this
case would be confusing to the caller, as they would be able to GET and
HEAD the container, just not issue a POST.