### PR TITLE
ProviderResponse.to_wsgi returns a status string.

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import eventlet
 import logging
+from swift.common.swob import RESPONSE_REASONS
 
 
 class ProviderResponse(object):
@@ -26,7 +27,9 @@ class ProviderResponse(object):
         self.body = body
 
     def to_wsgi(self):
-        return self.status, self.headers.items(), self.body
+        # WSGI expects an HTTP status + reason string
+        wsgi_status = '%d %s' % (self.status, RESPONSE_REASONS[self.status][0])
+        return wsgi_status, self.headers.items(), self.body
 
 
 class BaseSync(object):

--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -278,10 +278,10 @@ class S3SyncShunt(object):
             # We incur an extra request hit by checking for a possible SLO.
             manifest = provider.get_manifest(obj)
             self.logger.debug("Manifest: %s" % manifest)
-            status_code, headers, app_iter = provider.shunt_object(req, obj)
+            status, headers, app_iter = provider.shunt_object(req, obj)
             put_headers = convert_to_local_headers(headers)
 
-            if response_is_complete(status_code, headers):
+            if response_is_complete(int(status.split()[0]), headers):
                 if check_slo(put_headers) and manifest:
                     app_iter = SwiftSloPutWrapper(
                         app_iter, put_headers, req.environ['PATH_INFO'],
@@ -291,8 +291,7 @@ class S3SyncShunt(object):
                         app_iter, put_headers, req.environ['PATH_INFO'],
                         self.app, self.logger)
         else:
-            status_code, headers, app_iter = provider.shunt_object(req, obj)
-        status = '%s %s' % (status_code, swob.RESPONSE_REASONS[status_code][0])
+            status, headers, app_iter = provider.shunt_object(req, obj)
         self.logger.debug('Remote resp: %s' % status)
 
         headers = filter_hop_by_hop_headers(headers)

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -278,7 +278,7 @@ class SyncSwift(BaseSync):
                 else:
                     resp = getattr(client, op)(container, key, **args)
                 if not resp:
-                    return ProviderResponse(True, '204 No Content', {}, [''])
+                    return ProviderResponse(True, 204, {}, [''])
 
                 if isinstance(resp, tuple):
                     headers, body = resp

--- a/test/unit/test_shunt.py
+++ b/test/unit/test_shunt.py
@@ -62,7 +62,7 @@ class TestShunt(unittest.TestCase):
             's3_sync.sync_s3.SyncS3.list_objects')]
         self.mock_shunt_swift = self.patchers[0].__enter__()
         self.mock_shunt_swift.return_value = (
-            200, [
+            '200 OK', [
                 ('Remote-x-openstack-request-id', 'also some trans id'),
                 ('Remote-x-trans-id', 'some trans id'),
                 ('CONNECTION', 'bad'),
@@ -77,7 +77,7 @@ class TestShunt(unittest.TestCase):
             ], StringIO.StringIO('remote swift'))
         self.mock_shunt_s3 = self.patchers[1].__enter__()
         self.mock_shunt_s3.return_value = (
-            200, [
+            '200 OK', [
                 ('Remote-x-amz-id-2', 'also some trans id'),
                 ('Remote-x-amz-request-id', 'some trans id'),
                 ('CONNECTION', 'bad'),
@@ -378,25 +378,25 @@ class TestShunt(unittest.TestCase):
         payload = 'bytes from remote'
         responses = [
             ('AUTH_tee/tee',
-             (200,
+             ('200 OK',
               [('Content-Length', len(payload)),
                (utils.SLO_HEADER, 'True'),
                ('etag', 'deadbeef-2')],
               StringIO.StringIO(payload)),
              mock_s3_shunt, True),
             (u'AUTH_a/sw\u00e9ft',
-             (200,
+             ('200 OK',
               [('Content-Length', len(payload)),
                (utils.SLO_HEADER, 'True'),
                ('etag', 'etag')],
               StringIO.StringIO(payload)),
              mock_swift_shunt, True),
             ('AUTH_tee/tee',
-             (200, [('Content-Length', len(payload)), ('etag', 'etag')],
+             ('200 OK', [('Content-Length', len(payload)), ('etag', 'etag')],
               StringIO.StringIO(payload)),
              mock_s3_shunt, True),
             (u'AUTH_a/sw\u00e9ft',
-             (200, [('Content-Length', len(payload)), ('etag', 'etag')],
+             ('200 OK', [('Content-Length', len(payload)), ('etag', 'etag')],
               StringIO.StringIO(payload)),
              mock_swift_shunt, True)
         ]

--- a/test/unit/test_sync_s3.py
+++ b/test/unit/test_sync_s3.py
@@ -1226,7 +1226,8 @@ class TestSyncS3(unittest.TestCase):
             status, headers, body_iter = self.sync_s3.shunt_object(req, key)
             self.assertEqual(
                 test['conns_start'], self.sync_s3.client_pool.free_count())
-            self.assertEqual(status, resp_meta['HTTPStatusCode'])
+            self.assertEqual(status.split()[0],
+                             str(resp_meta['HTTPStatusCode']))
             self.assertEqual(sorted(headers), sorted(expected_headers.items()))
             self.assertEqual(b''.join(body_iter), body)
             mocked.assert_called_once_with(Bucket=self.aws_bucket, Key=s3_name)
@@ -1260,7 +1261,7 @@ class TestSyncS3(unittest.TestCase):
             'If-Unmodified-Since': 'ius',
         })
         status, headers, body_iter = self.sync_s3.shunt_object(req, key)
-        self.assertEqual(status, 304)
+        self.assertEqual(status.split()[0], str(304))
         self.assertEqual(headers, [('Content-Length', 12)])
         self.assertEqual(b''.join(body_iter), body)
         self.assertEqual(self.mock_boto3_client.get_object.mock_calls,
@@ -1275,7 +1276,7 @@ class TestSyncS3(unittest.TestCase):
         # Again, but with HEAD
         req.method = 'HEAD'
         status, headers, body_iter = self.sync_s3.shunt_object(req, key)
-        self.assertEqual(status, 304)
+        self.assertEqual(status.split()[0], str(304))
         self.assertEqual(headers, [])
         self.assertEqual(b''.join(body_iter), b'')
         self.assertEqual(self.mock_boto3_client.head_object.mock_calls,
@@ -1329,7 +1330,7 @@ class TestSyncS3(unittest.TestCase):
             if test['method'] == 'GET':
                 self.assertEqual(test['conns_start'],
                                  self.sync_s3.client_pool.free_count())
-            self.assertEqual(status, test['status'])
+            self.assertEqual(status.split()[0], str(test['status']))
             self.assertEqual(headers, test['headers'])
             self.assertEqual(b''.join(body_iter), test['message'])
             mocked.assert_called_once_with(Bucket=self.aws_bucket,

--- a/test/unit/test_sync_swift.py
+++ b/test/unit/test_sync_swift.py
@@ -492,7 +492,7 @@ class TestSyncSwift(unittest.TestCase):
             status, headers, body_iter = self.sync_swift.shunt_object(req, key)
             self.assertEqual(
                 test['conns_start'], self.sync_swift.client_pool.free_count())
-            self.assertEqual(status, 200)
+            self.assertEqual(status.split()[0], str(200))
             self.assertEqual(sorted(headers), sorted(expected_headers.items()))
             self.assertEqual(b''.join(body_iter), content)
             self.assertEquals(mocked.mock_calls, test['calls'])
@@ -526,7 +526,7 @@ class TestSyncSwift(unittest.TestCase):
             'swift.trans_id': 'local transaction id',
         }, headers={'Range': 'bytes=10-20'})
         status, headers, body_iter = self.sync_swift.shunt_object(req, key)
-        self.assertEqual(status, 206)
+        self.assertEqual(status.split()[0], str(206))
         self.assertEqual(sorted(headers), expected_headers)
         self.assertEqual(b''.join(body_iter), body)
         self.assertEqual(swift_client.get_object.mock_calls, [
@@ -539,7 +539,7 @@ class TestSyncSwift(unittest.TestCase):
         status, headers, body_iter = self.sync_swift.shunt_object(req, key)
         # This test doesn't exactly match Swift's behavior: on HEAD with Range
         # Swift will respond 200, but with no Content-Range
-        self.assertEqual(status, 206)
+        self.assertEqual(status.split()[0], str(206))
         self.assertEqual(sorted(headers), expected_headers)
         self.assertEqual(b''.join(body_iter), '')
         self.assertEqual(swift_client.head_object.mock_calls, [
@@ -604,7 +604,7 @@ class TestSyncSwift(unittest.TestCase):
             status, headers, body_iter = self.sync_swift.shunt_object(req, key)
             self.assertEqual(
                 test['conns_start'], self.sync_swift.client_pool.free_count())
-            self.assertEqual(status, test['status'])
+            self.assertEqual(status.split()[0], str(test['status']))
             self.assertEqual(headers, test['headers'])
             self.assertEqual(b''.join(body_iter), test['message'])
             mocked_method.assert_has_calls([test['mock_call']])


### PR DESCRIPTION
The WSGI contract is that the status passed to start_response() should
be a string consisting of an HTTP status and HTTP reason. Previously,
the call to to_wsgi() method in ProviderResponse would return an
integer and we had some hooks to convert the status to a string in some
places.

The goal of this patch is to standardize the behavior where
ProviderResponse.to_wsgi will always return a valid status string and we
do not have to worry about converting it. It also simplifies the logic
when constructing the responses, as we can always create the
ProviderResponse object with an integer status. The Swift
swob.RESPONSE_REASONS is used for the lookup of HTTP reason.