### PR TITLE
Handle unicode object metadata; remove the extra HEAD request; fix all-container migrations.

### DIFF
--- a/s3_sync/migrator.py
+++ b/s3_sync/migrator.py
@@ -618,9 +618,6 @@ class Migrator(object):
             ts = Timestamp((ts - EPOCH).total_seconds()).internal
             headers['x-timestamp'] = ts
         del headers['last-modified']
-        # Encode all headers as UTF8
-        headers = {k.encode('utf8'): v.encode('utf8')
-                   for k, v in headers.items()}
         with self.ic_pool.item() as ic:
             try:
                 ic.upload_object(

--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -73,6 +73,13 @@ def maybe_munge_profile_for_all_containers(sync_profile, container_name):
 
     Otherwise, the original profile is returned and per_account will be False.
     """
+    # This can only occur for migrations
+    if sync_profile['aws_bucket'] == '/*':
+        new_profile = dict(sync_profile,
+                           aws_bucket=container_name.decode('utf-8'),
+                           container=container_name.decode('utf-8'))
+        return new_profile, False
+
     if sync_profile['container'] == '/*':
         new_profile = dict(sync_profile,
                            container=container_name.decode('utf-8'))

--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -332,6 +332,8 @@ class S3SyncShunt(object):
                         self.app, self.logger)
         else:
             status, headers, app_iter = provider.shunt_object(req, obj)
+        headers = [(k.encode('utf-8'), unicode(v).encode('utf-8'))
+                   for k, v in headers]
         self.logger.debug('Remote resp: %s' % status)
 
         headers = filter_hop_by_hop_headers(headers)

--- a/s3_sync/sync_s3.py
+++ b/s3_sync/sync_s3.py
@@ -336,12 +336,20 @@ class SyncS3(BaseSync):
                     dict(subdir=urllib.unquote(row['Prefix'])[key_offset:],
                          content_location=content_location)
                     for row in resp.get('CommonPrefixes', [])]
-                return (200, sorted(
+                response_body = sorted(
                     keys + prefixes,
-                    key=lambda x: x['name'] if 'name' in x else x['subdir']))
+                    key=lambda x: x['name'] if 'name' in x else x['subdir'])
+                return ProviderResponse(
+                    True,
+                    resp['ResponseMetadata']['HTTPStatusCode'],
+                    resp['ResponseMetadata']['HTTPHeaders'],
+                    response_body)
         except botocore.exceptions.ClientError as e:
-            return (e.response['ResponseMetadata']['HTTPStatusCode'],
-                    e.message)
+            return ProviderResponse(
+                False,
+                e.response['ResponseMetadata']['HTTPStatusCode'],
+                e.response['ResponseMetadata']['HTTPHeaders'],
+                e.message)
 
     def upload_slo(self, swift_key, storage_policy_index, s3_meta,
                    internal_client):

--- a/s3_sync/utils.py
+++ b/s3_sync/utils.py
@@ -525,7 +525,8 @@ def convert_to_swift_headers(s3_headers):
 
 
 def convert_to_local_headers(headers, remove_timestamp=True):
-    put_headers = dict([(k, v) for k, v in headers
+    put_headers = dict([(k.encode('utf-8'), unicode(v).encode('utf-8'))
+                        for k, v in headers
                         if not k.startswith('Remote-')])
     # We must remove the X-Timestamp header, as otherwise objects may
     # never be restored if a tombstone is present (as the remote

--- a/s3_sync/verify.py
+++ b/s3_sync/verify.py
@@ -68,10 +68,10 @@ def validate_bucket(provider, swift_key, create_bucket):
     if result.headers['x-object-meta-cloud-sync'] != 'fabcab':
         return 'Unexpected headers after setting metadata: %s' % result.headers
 
-    status, objects = provider.list_objects(
+    result = provider.list_objects(
         marker='', limit=1, prefix='', delimiter='')
-    if status != 200:
-        return 'Unexpected status code listing bucket: %s' % status
+    if result.status != 200:
+        return 'Unexpected status code listing bucket: %d' % result.status
 
     result = provider.delete_object(swift_key)
     if result is not None:

--- a/test/integration/test_migrator.py
+++ b/test/integration/test_migrator.py
@@ -415,11 +415,11 @@ class TestMigrator(TestCloudSyncBase):
 
         test_objects = [
             ('swift-blobBBB2', 'blob content', {}),
-            ('swift-2unicod\u00e9', '\xde\xad\xbe\xef', {}),
+            (u'swift-2unicod\u00e9', '\xde\xad\xbe\xef', {}),
             ('swift-2with-headers',
              'header-blob',
              {'x-object-meta-custom-header': 'value',
-              'x-object-meta-unicod\u00e9': '\u262f',
+              u'x-object-meta-unicod\u00e9': u'\u262f',
               'content-type': 'migrator/test',
               'content-disposition': "attachment; filename='test-blob.jpg'",
               'content-encoding': 'identity',

--- a/test/integration/test_migrator.py
+++ b/test/integration/test_migrator.py
@@ -462,6 +462,28 @@ class TestMigrator(TestCloudSyncBase):
                     self.assertIn(k, hdrs)
                     self.assertEqual(v, hdrs[k])
 
+    def test_shunt_all_containers(self):
+        test_objects = [
+            ('swift-blobBBB2', 'blob content', {}),
+            (u'swift-2unicod\u00e9', '\xde\xad\xbe\xef', {}),
+            ('swift-2with-headers',
+             'header-blob',
+             {'x-object-meta-custom-header': 'value',
+              u'x-object-meta-unicod\u00e9': u'\u262f',
+              'content-type': 'migrator/test',
+              'content-disposition': "attachment; filename='test-blob.jpg'",
+              'content-encoding': 'identity',
+              'x-delete-at': str(int(time.time() + 7200))})]
+
+        self.swift_nuser.put_container('container')
+        for name, body, headers in test_objects:
+            self.nuser_swift('put_object', 'container', name,
+                             StringIO.StringIO(body), headers=headers)
+        _, listing = self.nuser2_swift('get_container', 'container')
+        self.assertEqual(
+            sorted([obj[0] for obj in test_objects]),
+            [obj['name'] for obj in listing])
+
     def test_propagate_delete(self):
         migration = self.swift_migration()
         key = 'test_delete_object'

--- a/test/unit/test_migrator.py
+++ b/test/unit/test_migrator.py
@@ -800,11 +800,12 @@ class TestMigrator(unittest.TestCase):
                     True, 200, objects[name]['remote_headers'],
                     StringIO('object body'))
 
-            provider.list_objects.return_value = (
-                200, [{'name': name,
-                       'last_modified': objects[name]['list-time'],
-                       'hash': objects[name]['hash']}
-                      for name in objects.keys()])
+            provider.list_objects.return_value = ProviderResponse(
+                True, 200, {},
+                [{'name': name,
+                  'last_modified': objects[name]['list-time'],
+                  'hash': objects[name]['hash']}
+                 for name in objects.keys()])
             provider.head_bucket.return_value = mock.Mock(
                 status=200, headers={})
             provider.get_object.side_effect = get_object
@@ -827,7 +828,8 @@ class TestMigrator(unittest.TestCase):
         buckets = [{'name': 'bucket1'}, {'name': 'bucket2'}]
         provider_mock.list_buckets.return_value = ProviderResponse(
             True, 200, [], buckets)
-        provider_mock.list_objects.return_value = (200, [{'name': 'obj'}])
+        provider_mock.list_objects.return_value = ProviderResponse(
+            True, 200, {}, [{'name': 'obj'}])
         provider_mock.get_object.return_value = ProviderResponse(
             True, 200, {'last-modified': create_timestamp(1.5e9)},
             StringIO(''))
@@ -920,7 +922,8 @@ class TestMigrator(unittest.TestCase):
 
         self.migrator.status = mock.Mock()
         self.migrator.status.get_migration.return_value = {'marker': 'zzz'}
-        provider.list_objects.return_value = (200, [])
+        provider.list_objects.return_value = ProviderResponse(
+            True, 200, {}, [])
         self.swift_client.iter_objects.return_value = iter([])
 
         self.migrator.next_pass()
@@ -944,7 +947,8 @@ class TestMigrator(unittest.TestCase):
 
             provider.reset_mock()
             self.swift_client.reset_mock()
-            provider.list_objects.return_value = (200, [{'name': 'test'}])
+            provider.list_objects.return_value = ProviderResponse(
+                True, 200, {}, [{'name': 'test'}])
             provider.get_object.return_value = ProviderResponse(
                 True, 200, {'last-modified': create_timestamp(1.5e9)},
                 StringIO(''))
@@ -997,7 +1001,8 @@ class TestMigrator(unittest.TestCase):
         self.migrator.config['protocol'] = 'swift'
 
         provider = create_provider_mock.return_value
-        provider.list_objects.return_value = (200, [{'name': 'test'}])
+        provider.list_objects.return_value = ProviderResponse(
+            True, 200, {}, [{'name': 'test'}])
 
         resp = mock.Mock()
         resp.status = 404
@@ -1018,7 +1023,8 @@ class TestMigrator(unittest.TestCase):
     @mock.patch('s3_sync.migrator.create_provider')
     def test_create_container_timeout(self, create_provider_mock, time_mock):
         provider = create_provider_mock.return_value
-        provider.list_objects.return_value = (200, [{'name': 'test'}])
+        provider.list_objects.return_value = ProviderResponse(
+            True, 200, {}, [{'name': 'test'}])
 
         resp = mock.Mock()
         resp.status = 200
@@ -1137,8 +1143,8 @@ class TestMigrator(unittest.TestCase):
         bucket_resp.headers = {}
 
         provider.head_bucket.return_value = bucket_resp
-        provider.list_objects.return_value = (
-            200, [{'name': 'slo'}])
+        provider.list_objects.return_value = ProviderResponse(
+            True, 200, {}, [{'name': 'slo'}])
         provider.get_object.side_effect = get_object
         provider.head_object.side_effect = head_object
         provider.get_manifest.return_value = manifest
@@ -1297,12 +1303,14 @@ class TestMigrator(unittest.TestCase):
 
         def list_objects(marker, chunk, prefix, bucket=None):
             if bucket is None or bucket == self.migrator.config['container']:
-                return (200, [{'name': 'dlo'}])
+                return ProviderResponse(True, 200, {}, [{'name': 'dlo'}])
             elif bucket == segments_container:
                 if marker == '':
-                    return (200, [{'name': '1'}, {'name': '2'}, {'name': '3'}])
+                    return ProviderResponse(
+                        True, 200, {},
+                        [{'name': '1'}, {'name': '2'}, {'name': '3'}])
                 if marker == '3':
-                    return (200, [])
+                    return ProviderResponse(True, 200, {}, [])
             raise RuntimeError('Unknown container')
 
         self.swift_client.container_exists.side_effect = container_exists
@@ -1410,9 +1418,10 @@ class TestMigrator(unittest.TestCase):
         self.swift_client.get_object_metadata.side_effect =\
             _get_object_metadata
         self.swift_client.get_object.side_effect = _get_object
-        provider.list_objects.return_value = (200, [
-            dict([('name', k)] + objects[k]['list_entry'].items())
-            for k in sorted(objects.keys())])
+        provider.list_objects.return_value = ProviderResponse(
+            True, 200, {},
+            [dict([('name', k)] + objects[k]['list_entry'].items())
+             for k in sorted(objects.keys())])
         provider.head_object.side_effect = _head_object
         provider.head_bucket.return_value = mock.Mock(status=200, headers={})
         provider.get_manifest.return_value = {}

--- a/test/unit/test_shunt.py
+++ b/test/unit/test_shunt.py
@@ -361,7 +361,7 @@ class TestShunt(unittest.TestCase):
                 self.assertEqual(headers, [
                     ('Remote-x-openstack-request-id', 'also some trans id'),
                     ('Remote-x-trans-id', 'some trans id'),
-                    ('Content-Length', 12)
+                    ('Content-Length', '12')
                 ])
                 self.assertEqual(b''.join(body_iter), b'remote swift')
                 self.mock_shunt_swift.reset_mock()

--- a/test/unit/test_shunt.py
+++ b/test/unit/test_shunt.py
@@ -23,6 +23,7 @@ import unittest
 
 from swift.common import swob
 
+from s3_sync.base_sync import ProviderResponse
 from s3_sync import shunt
 from s3_sync import sync_s3
 from s3_sync import sync_swift
@@ -474,19 +475,21 @@ class TestShunt(unittest.TestCase):
 
     def test_list_container_shunt_s3(self):
         self.mock_list_s3.side_effect = [
-            (200, [{'name': 'abc',
-                    'hash': 'ffff',
-                    'bytes': 42,
-                    'last_modified': 'date',
-                    'content_type': 'type',
-                    'content_location': 'mock-s3:bucket'},
-                   {'name': u'unicod\xe9',
-                    'hash': 'ffff',
-                    'bytes': 1000,
-                    'last_modified': 'date',
-                    'content_type': 'type',
-                    'content_location': 'mock-s3:bucket'}]),
-            (200, [])]
+            ProviderResponse(
+                True, 200, {},
+                [{'name': 'abc',
+                  'hash': 'ffff',
+                  'bytes': 42,
+                  'last_modified': 'date',
+                  'content_type': 'type',
+                  'content_location': 'mock-s3:bucket'},
+                 {'name': u'unicod\xe9',
+                  'hash': 'ffff',
+                  'bytes': 1000,
+                  'last_modified': 'date',
+                  'content_type': 'type',
+                  'content_location': 'mock-s3:bucket'}]),
+            ProviderResponse(True, 200, {}, [])]
         req = swob.Request.blank(
             '/v1/AUTH_a/s3',
             environ={'__test__.status': '200 OK',
@@ -514,7 +517,8 @@ class TestShunt(unittest.TestCase):
                      'content_type': 'type',
                      'content_location': 'http://some-swift'}]
         self.mock_list_s3.side_effect = [
-            (200, elements), (200, [])]
+            ProviderResponse(True, 200, {}, elements),
+            ProviderResponse(True, 200, {}, [])]
         req = swob.Request.blank(
             '/v1/AUTH_a/s3?format=xml',
             environ={'__test__.status': '200 OK',
@@ -563,7 +567,8 @@ class TestShunt(unittest.TestCase):
                      'content_location': 'mock-s3:bucket'}]
         mock_result = [dict(entry) for entry in elements]
         self.mock_list_s3.side_effect = [
-            (200, mock_result), (200, [])]
+            ProviderResponse(True, 200, {}, mock_result),
+            ProviderResponse(True, 200, {}, [])]
         req = swob.Request.blank(
             '/v1/AUTH_a/s3',
             environ={'__test__.status': '200 OK',
@@ -613,7 +618,8 @@ class TestShunt(unittest.TestCase):
                      'content_location': 's3-account:bucket'}]
         mock_result = [dict(entry) for entry in elements]
         self.mock_list_s3.side_effect = [
-            (200, mock_result), (200, [])]
+            ProviderResponse(True, 200, {}, mock_result),
+            ProviderResponse(True, 200, {}, [])]
         req = swob.Request.blank(
             '/v1/AUTH_a/s3?format=json',
             environ={'__test__.status': '200 OK',
@@ -647,7 +653,8 @@ class TestShunt(unittest.TestCase):
                      'content_location': 'mock-s3:bucket'}]
         mock_result = [dict(entry) for entry in elements]
         self.mock_list_s3.side_effect = [
-            (200, mock_result), (200, [])]
+            ProviderResponse(True, 200, {}, mock_result),
+            ProviderResponse(True, 200, {}, [])]
         req = swob.Request.blank(
             '/v1/AUTH_a/s3',
             environ={'__test__.status': '200 OK',
@@ -670,7 +677,8 @@ class TestShunt(unittest.TestCase):
     @mock.patch('s3_sync.shunt.create_provider')
     def test_list_container_shunt_all_containers(self, create_mock):
         create_mock.return_value = mock.Mock()
-        create_mock.return_value.list_objects.return_value = (200, [])
+        create_mock.return_value.list_objects.return_value = ProviderResponse(
+            True, 200, {}, [])
         req = swob.Request.blank(
             '/v1/AUTH_b/s3',
             environ={'__test__.status': '200 OK',
@@ -704,19 +712,21 @@ class TestShunt(unittest.TestCase):
 
     def test_list_container_shunt_swift(self):
         self.mock_list_swift.side_effect = [
-            (200, [{'name': 'abc',
-                    'hash': 'ffff',
-                    'bytes': 42,
-                    'last_modified': 'date',
-                    'content_type': 'type',
-                    'content_location': 'http://some-swift'},
-                   {'name': u'unicod\xe9',
-                    'hash': 'ffff',
-                    'bytes': 1000,
-                    'last_modified': 'date',
-                    'content_type': 'type',
-                    'content_location': 'http://some-swift'}]),
-            (200, [])]
+            ProviderResponse(
+                True, 200, {},
+                [{'name': 'abc',
+                  'hash': 'ffff',
+                  'bytes': 42,
+                  'last_modified': 'date',
+                  'content_type': 'type',
+                  'content_location': 'http://some-swift'},
+                 {'name': u'unicod\xe9',
+                  'hash': 'ffff',
+                  'bytes': 1000,
+                  'last_modified': 'date',
+                  'content_type': 'type',
+                  'content_location': 'http://some-swift'}]),
+            ProviderResponse(True, 200, {}, [])]
         req = swob.Request.blank(
             '/v1/AUTH_a/sw\xc3\xa9ft',
             environ={'__test__.status': '200 OK',
@@ -732,23 +742,25 @@ class TestShunt(unittest.TestCase):
 
     def test_list_container_shunt_with_duplicates(self):
         self.mock_list_swift.side_effect = [
-            (200, [{'subdir': u'a/',
-                    'content_location': 'http://some-swift'},
-                   {'name': u'unicod\xe9',
-                    'hash': 'ffff',
-                    'bytes': 1000,
-                    'last_modified': 'date',
-                    'content_type': 'type',
-                    'content_location': 'http://some-swift'},
-                   {'subdir': u'z/',
-                    'content_location': 'http://some-swift'},
-                   {'name': u'zzzzz',
-                    'hash': 'ffff',
-                    'bytes': 1000,
-                    'last_modified': 'date',
-                    'content_type': 'type',
-                    'content_location': 'http://some-swift'}]),
-            (200, [])]
+            ProviderResponse(
+                True, 200, {},
+                [{'subdir': u'a/',
+                  'content_location': 'http://some-swift'},
+                 {'name': u'unicod\xe9',
+                  'hash': 'ffff',
+                  'bytes': 1000,
+                  'last_modified': 'date',
+                  'content_type': 'type',
+                  'content_location': 'http://some-swift'},
+                 {'subdir': u'z/',
+                  'content_location': 'http://some-swift'},
+                 {'name': u'zzzzz',
+                  'hash': 'ffff',
+                  'bytes': 1000,
+                  'last_modified': 'date',
+                  'content_type': 'type',
+                  'content_location': 'http://some-swift'}]),
+            ProviderResponse(True, 200, {}, [])]
         # simulate being partially migrated
         local_data = [
             {'name': u'a',

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -78,7 +78,7 @@ class TestUtilsFunctions(unittest.TestCase):
                           'x-object-meta': 'object-meta',
                           'etag': 'deadbeef'}.items()))
         self.assertEqual(
-            {'content-type': 'application/test', 'x-timestamp': 12345},
+            {'content-type': 'application/test', 'x-timestamp': '12345'},
             utils.convert_to_local_headers(
                 {'Remote-x-object-meta': 'foo',
                  'x-timestamp': 12345,

--- a/test/unit/test_verify.py
+++ b/test/unit/test_verify.py
@@ -215,7 +215,7 @@ class TestMainTrackClientCalls(unittest.TestCase):
         ]
         mock_client.list_objects.return_value = {
             'Contents': [],
-            'ReponseMetadata': {
+            'ResponseMetadata': {
                 'HTTPStatusCode': 200,
                 'HTTPHeaders': {
                     'x-amz-meta-cloud-sync': 'fabcab',
@@ -294,7 +294,7 @@ class TestMainTrackClientCalls(unittest.TestCase):
         ]
         mock_client.list_objects.return_value = {
             'Contents': [],
-            'ReponseMetadata': {
+            'ResponseMetadata': {
                 'HTTPStatusCode': 200,
                 'HTTPHeaders': {
                     'x-amz-meta-cloud-sync': 'fabcab',


### PR DESCRIPTION
I found a few other bugs that the original PR uncovered. There are three total commits:
1. Properly handle all-container migrations
2. Removing the extra HEAD request (the refactoring is also important for the GET Account work)
3. Unicode fixes

It's probably best to review this one commit at a time. Collectively, the PR is a bit too big, but I tried to keep individual commits more manageable.

All-container migrations
--------------------------------

This commit fixes the case where we never change the `aws_bucket` parameter of the `sync_profile` to the container that the migration is currently attempting to process. This leads to 412 errors from the shunt (because `/*` is not a valid container name) and the shunt is de facto useless. Unfortunately, we did not have a test that covers this.

Removing the extra HEAD request
-----------------------------------------------

I ended up doing a bit of refactoring here. I think the logic is a bit simpler now, the extra HEAD is gone, and I managed to make `list_objects` use the same interface as the other similar methods. The patch changes the API to return a ProviderResponse (like the other
methods) and refactors the listing handling to take advantage of the
additional information. Majority of the changes are related to fixing
the tests for the API change.


Unicode fixes
------------------

This fell out when I tried to fix up the tests that attempted to use unicode in object names and headers. It's not entirely related to the other changes -- happy to split it out in a separate PR.