### PR TITLE
Avoid ValueError in get_account_info

### DIFF
--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -48,8 +48,12 @@ class S3SyncProxyFSSwitch(object):
         if 'pfs.is_bimodal' in env:
             return env['pfs.is_bimodal']
 
-        parts = env['PATH_INFO'].split('/', 3)
-        if len(parts) < 3 or parts[1] not in ('v1', 'v1.0'):
+        try:
+            # Need at least an account
+            vers, a, c, o = utils.split_path(env['PATH_INFO'], 2, 4, True)
+            if not constraints.valid_api_version(vers):
+                raise ValueError
+        except ValueError:
             # If it's not a swift request, it can't be a ProxyFS request
             return False
 

--- a/test/unit/test_shunt.py
+++ b/test/unit/test_shunt.py
@@ -319,6 +319,9 @@ class TestShunt(unittest.TestCase):
             req.call_application(self.app)
             self.assertEqual(self.mock_shunt_swift.mock_calls, [])
             self.assertEqual(self.mock_shunt_s3.mock_calls, [])
+        # Just plain bad; crazy talk
+        _test_no_shunt('/v1//', '404 Not Found')
+        _test_no_shunt('/not/a/swift/request', '404 Not Found')
         # Not an affected container
         _test_no_shunt('/v1/AUTH_a/c/o', '404 Not Found')
         _test_no_shunt('/v1/AUTH_a/c/o', '404 Not Found')


### PR DESCRIPTION
... by trying to raise (and catch) it ourselves first. Seen in the wild:

    Traceback (most recent call last):
      File ".../swift/common/middleware/catch_errors.py", line 41, in handle_request
        resp = self._app_call(env)
      ...
      File ".../s3_sync/shunt.py", line 42, in __call__
        if self.is_proxy_fs(env) == self.should_handle_proxyfs:
      File ".../s3_sync/shunt.py", line 55, in is_proxy_fs
        account_info = get_account_info(env, self.base_app, swift_source='')
      File ".../swift/proxy/controllers/base.py", line 393, in get_account_info
        split_path(env['PATH_INFO'], 2, 4, True)
      File ".../swift/common/utils.py", line 1333, in split_path
        raise ValueError('Invalid path: %s' % quote(path))
    ValueError: Invalid path: /v1//