### PR TITLE
Use the proper ETag for SLO and content for DLO.

### DIFF
--- a/test/unit/test_migrator.py
+++ b/test/unit/test_migrator.py
@@ -16,6 +16,7 @@ limitations under the License.
 from contextlib import contextmanager
 import datetime
 import errno
+import hashlib
 import itertools
 import json
 import logging
@@ -1063,7 +1064,7 @@ class TestMigrator(unittest.TestCase):
 
         manifest = [{'name': '/'.join([segments_container, 'part1'])},
                     {'name': '/'.join([segments_container, 'part2'])}]
-
+        manifest_etag = hashlib.md5(json.dumps(manifest)).hexdigest()
         objects = {
             'slo': {
                 'remote_headers': {
@@ -1074,7 +1075,8 @@ class TestMigrator(unittest.TestCase):
                     'x-object-meta-custom': 'slo-meta',
                     'x-timestamp': Timestamp(1.5e9).internal,
                     'x-static-large-object': 'True',
-                    'Content-Length': str(len(json.dumps(manifest)))}
+                    'Content-Length': str(len(json.dumps(manifest))),
+                    'etag': manifest_etag}
             },
             'part1': {
                 'remote_headers': {


### PR DESCRIPTION
Our SLO/DLO uploads broke and we missed the 422 errors when attempting
to upload the manifests. There are two issues. For the SLO case, we
should be uploading the ETag of the *JSON content* rather than the ETag
returned by the origin Swift cluster (as there is no SLO middleware to
validate it).

For the DLO case, we have to GET the object with multipart-manifest=get
so that we retrieve the actual manifest blob. This is critical because a
DLO allows the manifest object to be non-zero size.

The patch fixes the large object tests that stopped working after the
migration shunt was put in place. There is also a small logger issue,
where we were no longer logging the actual requested objected on certain
failures.