### PR TITLE
Fix unicode handling in S3 migrations.

### DIFF
--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -479,6 +479,7 @@ class S3SyncShunt(object):
         if req.method == 'GET' and sync_profile.get('restore_object', False) \
                 and 'range' not in req.headers:
             # We incur an extra request hit by checking for a possible SLO.
+            obj = obj.decode('utf-8')
             manifest = provider.get_manifest(obj)
             self.logger.debug("Manifest: %s" % manifest)
             status, headers, app_iter = provider.shunt_object(req, obj)

--- a/test/integration/test_migrator.py
+++ b/test/integration/test_migrator.py
@@ -68,10 +68,9 @@ class TestMigrator(TestCloudSyncBase):
 
         test_objects = [
             ('s3-blob', 's3 content', {}, {}),
-            ('s3-unicod\u00e9', '\xde\xad\xbe\xef', {}, {}),
+            (u's3-unicod\u00e9', '\xde\xad\xbe\xef', {}, {}),
             ('s3-with-headers', 'header-blob',
-             {'custom-header': 'value',
-              'unicod\u00e9': '\u262f'},
+             {'custom-header': 'value'},
              {'content-type': 'migrator/test',
               'content-disposition': "attachment; filename='test-blob.jpg'",
               'content-encoding': 'identity'})]
@@ -85,8 +84,10 @@ class TestMigrator(TestCloudSyncBase):
         for name, body, headers, req_headers in test_objects:
             kwargs = dict([('Content' + key.split('-')[1].capitalize(), value)
                            for key, value in req_headers.items()])
-            self.s3('put_object', Bucket=migration['aws_bucket'], Key=name,
-                    Body=StringIO.StringIO(body), Metadata=headers,
+            self.s3('put_object', Bucket=migration['aws_bucket'],
+                    Key=name,
+                    Body=StringIO.StringIO(body),
+                    Metadata=headers,
                     **kwargs)
 
         with self.migrator_running():
@@ -296,11 +297,11 @@ class TestMigrator(TestCloudSyncBase):
 
         test_objects = [
             ('swift-blobBBBB', 'blob content', {}),
-            ('swift-unicod\u00e9', '\xde\xad\xbe\xef', {}),
+            (u'swift-unicod\u00e9', '\xde\xad\xbe\xef', {}),
             ('swift-with-headers',
              'header-blob',
              {'x-object-meta-custom-header': 'value',
-              'x-object-meta-unicod\u00e9': '\u262f',
+              u'x-object-meta-unicod\u00e9': u'\u262f',
               'content-type': 'migrator/test',
               'content-disposition': "attachment; filename='test-blob.jpg'",
               'content-encoding': 'identity',


### PR DESCRIPTION
Fixes handling of objects with unicode names and removes a test for
unicode characters in the metadata, as S3 does not support unicode
characters:
"Amazon S3 stores user-defined metadata keys in lowercase.
 Each key-value pair must conform to US-ASCII when you are using REST."
-- [1]

[1] https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html