### PR TITLE
Make container last-modified entry optional.

### DIFF
--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -271,8 +271,9 @@ class SyncSwift(BaseSync):
 
         if parse_modified:
             for container in resp.body:
-                container['last_modified'] = datetime.datetime.strptime(
-                    container['last_modified'], SWIFT_TIME_FMT)
+                if 'last_modified' in container:
+                    container['last_modified'] = datetime.datetime.strptime(
+                        container['last_modified'], SWIFT_TIME_FMT)
         return resp
 
     def _call_swiftclient(self, op, container, key, **args):


### PR DESCRIPTION
When listing containers (i.e. GET <Account>), the last-modified entry
for each container may not exist. This is true in old Swift clusters and
luckily we don't have to rely on it.