### PR TITLE
Delete migrated objects if source is removed.

### DIFF
--- a/s3_sync/utils.py
+++ b/s3_sync/utils.py
@@ -22,6 +22,8 @@ import urllib
 
 from swift.common.middleware.versioned_writes import (
     SYSMETA_VERSIONS_LOC, SYSMETA_VERSIONS_MODE)
+from swift.common.request_helpers import (
+    get_sys_meta_prefix, get_object_transient_sysmeta)
 from swift.common.swob import Request
 from swift.common.utils import FileLikeIter, close_if_possible
 
@@ -45,6 +47,7 @@ HOP_BY_HOP_HEADERS = set([
     'upgrade',
 ])
 PROPAGATED_HDRS = ['x-container-read', 'x-container-write']
+MIGRATOR_HEADER = 'multi-cloud-internal-migrator'
 
 
 class RemoteHTTPError(Exception):
@@ -663,3 +666,9 @@ def iter_listing(list_func, logger, marker, limit, prefix, *args):
 
     resp = list_func(marker, limit, prefix, *args)
     return resp, _results_iterator(resp)
+
+
+def get_sys_migrator_header(path_type):
+    if path_type == 'object':
+        return get_object_transient_sysmeta(MIGRATOR_HEADER)
+    return '%s%s' % (get_sys_meta_prefix(path_type), MIGRATOR_HEADER)

--- a/test/unit/test_migrator.py
+++ b/test/unit/test_migrator.py
@@ -701,7 +701,9 @@ class TestMigrator(unittest.TestCase):
                         'last-modified': create_timestamp(1.5e9)},
                     'expected_headers': {
                         'x-object-meta-custom': 'custom',
-                        'x-timestamp': Timestamp(1.5e9).internal},
+                        'x-timestamp': Timestamp(1.5e9).internal,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.5e9).internal)},
                     'list-time': create_list_timestamp(1.5e9),
                     'hash': 'etag'
                 },
@@ -711,7 +713,9 @@ class TestMigrator(unittest.TestCase):
                         'last-modified': create_timestamp(1.4e9)},
                     'expected_headers': {
                         'x-object-meta-custom': 'custom',
-                        'x-timestamp': Timestamp(1.4e9).internal},
+                        'x-timestamp': Timestamp(1.4e9).internal,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.4e9).internal)},
                     'list-time': create_list_timestamp(1.4e9),
                     'hash': 'etag'
                 }
@@ -724,7 +728,9 @@ class TestMigrator(unittest.TestCase):
                         'last-modified': create_timestamp(1.5e9)},
                     'expected_headers': {
                         'x-object-meta-custom': 'custom',
-                        'x-timestamp': Timestamp(1.5e9).internal},
+                        'x-timestamp': Timestamp(1.5e9).internal,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.5e9).internal)},
                     'list-time': create_list_timestamp(1.5e9),
                     'hash': 'etag'
                 },
@@ -734,7 +740,9 @@ class TestMigrator(unittest.TestCase):
                         'last-modified': create_timestamp(1.4e9)},
                     'expected_headers': {
                         'x-object-meta-custom': 'custom',
-                        'x-timestamp': Timestamp(1.4e9).internal},
+                        'x-timestamp': Timestamp(1.4e9).internal,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.4e9).internal)},
                     'list-time': create_list_timestamp(1.4e9),
                     'hash': 'etag'
                 }
@@ -751,7 +759,9 @@ class TestMigrator(unittest.TestCase):
                         'last-modified': create_timestamp(1.5e9)},
                     'expected_headers': {
                         'x-object-meta-custom': 'custom',
-                        'x-timestamp': Timestamp(1.5e9).internal},
+                        'x-timestamp': Timestamp(1.5e9).internal,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.5e9).internal)},
                     'list-time': create_list_timestamp(1.5e9),
                     'hash': 'etag'
                 },
@@ -761,7 +771,9 @@ class TestMigrator(unittest.TestCase):
                         'last-modified': create_timestamp(1.4e9)},
                     'expected_headers': {
                         'x-object-meta-custom': 'custom',
-                        'x-timestamp': Timestamp(1.4e9).internal},
+                        'x-timestamp': Timestamp(1.4e9).internal,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.4e9).internal)},
                     'list-time': create_list_timestamp(1.4e9),
                     'hash': 'etag'
                 }
@@ -787,7 +799,9 @@ class TestMigrator(unittest.TestCase):
                         'last-modified': create_timestamp(1.5e9)},
                     'expected_headers': {
                         'x-object-meta-custom': 'custom',
-                        'x-timestamp': Timestamp(1.5e9).internal},
+                        'x-timestamp': Timestamp(1.5e9).internal,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.5e9).internal)},
                     'list-time': create_list_timestamp(1.5e9),
                     'hash': 'etag'
                 },
@@ -797,7 +811,9 @@ class TestMigrator(unittest.TestCase):
                         'last-modified': create_timestamp(1.4e9)},
                     'expected_headers': {
                         'x-object-meta-custom': 'custom',
-                        'x-timestamp': Timestamp(1.4e9).internal},
+                        'x-timestamp': Timestamp(1.4e9).internal,
+                        s3_sync.utils.get_sys_migrator_header('object'): str(
+                            Timestamp(1.4e9).internal)},
                     'list-time': create_list_timestamp(1.4e9),
                     'hash': 'etag'
                 }
@@ -1132,7 +1148,9 @@ class TestMigrator(unittest.TestCase):
                     'x-timestamp': Timestamp(1.5e9).internal,
                     'x-static-large-object': 'True',
                     'Content-Length': str(len(json.dumps(manifest))),
-                    'etag': manifest_etag}
+                    'etag': manifest_etag,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.5e9).internal)}
             },
             'part1': {
                 'remote_headers': {
@@ -1140,7 +1158,9 @@ class TestMigrator(unittest.TestCase):
                     'last-modified': create_timestamp(1.4e9)},
                 'expected_headers': {
                     'x-object-meta-part': 'part-1',
-                    'x-timestamp': Timestamp(1.4e9).internal}
+                    'x-timestamp': Timestamp(1.4e9).internal,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.4e9).internal)}
             },
             'part2': {
                 'remote_headers': {
@@ -1148,7 +1168,9 @@ class TestMigrator(unittest.TestCase):
                     'last-modified': create_timestamp(1.1e9)},
                 'expected_headers': {
                     'x-object-meta-part': 'part-2',
-                    'x-timestamp': Timestamp(1.1e9).internal}
+                    'x-timestamp': Timestamp(1.1e9).internal,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.1e9).internal)}
             }
         }
 
@@ -1307,7 +1329,9 @@ class TestMigrator(unittest.TestCase):
                 'expected_headers': {
                     'x-object-meta-custom': 'dlo-meta',
                     'x-timestamp': Timestamp(1.5e9).internal,
-                    'x-object-manifest': '%s/' % segments_container}
+                    'x-object-manifest': '%s/' % segments_container,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.5e9).internal)}
             },
             '1': {
                 'remote_headers': {
@@ -1315,7 +1339,9 @@ class TestMigrator(unittest.TestCase):
                     'last-modified': create_timestamp(1.4e9)},
                 'expected_headers': {
                     'x-object-meta-part': 'part-1',
-                    'x-timestamp': Timestamp(1.4e9).internal}
+                    'x-timestamp': Timestamp(1.4e9).internal,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.4e9).internal)}
             },
             '2': {
                 'remote_headers': {
@@ -1323,7 +1349,9 @@ class TestMigrator(unittest.TestCase):
                     'last-modified': create_timestamp(1.1e9)},
                 'expected_headers': {
                     'x-object-meta-part': 'part-2',
-                    'x-timestamp': Timestamp(1.1e9).internal}
+                    'x-timestamp': Timestamp(1.1e9).internal,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.1e9).internal)}
             },
             '3': {
                 'remote_headers': {
@@ -1331,7 +1359,9 @@ class TestMigrator(unittest.TestCase):
                     'last-modified': create_timestamp(1.2e9)},
                 'expected_headers': {
                     'x-object-meta-part': 'part-3',
-                    'x-timestamp': Timestamp(1.2e9).internal}
+                    'x-timestamp': Timestamp(1.2e9).internal,
+                    s3_sync.utils.get_sys_migrator_header('object'): str(
+                        Timestamp(1.2e9).internal)}
             }
         }
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -112,6 +112,17 @@ class TestUtilsFunctions(unittest.TestCase):
         self.assertEqual(expected, utils.diff_container_headers(
             hdrs_remote, hdrs_local))
 
+    def test_sys_migrator_header(self):
+        self.assertEqual(
+            'x-account-sysmeta-' + utils.MIGRATOR_HEADER,
+            utils.get_sys_migrator_header('account'))
+        self.assertEqual(
+            'x-container-sysmeta-' + utils.MIGRATOR_HEADER,
+            utils.get_sys_migrator_header('container'))
+        self.assertEqual(
+            'x-object-transient-sysmeta-' + utils.MIGRATOR_HEADER,
+            utils.get_sys_migrator_header('object'))
+
 
 class FakeSwift(object):
     def __init__(self):


### PR DESCRIPTION
When source objects are removed and there were no changes to the
destination objects, the migrator should remove the destination objects.
This allows us to handle properly a case where clients continue to
mutate the state of the source object store before switching over to
using the destination store (after some number of objects have been
migrated).

The approach introduces a Swift SYSMETA header that is used to tag all
objects on PUT into the destination. When an object's metadata is
updated or a PUT is issued, this header is overwritten. This allows us
to detect changes and delete objects only if they have not been by
mutated on the destination cluster.