### PR TITLE
Add provider put_object() methods.

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -157,6 +157,22 @@ class BaseSync(object):
             self.aws_bucket,
         )
 
+    def put_object(self, swift_key, headers, body_iter, query_string=None):
+        """
+        Uploads a single object to the provider's object store, as configured
+        (container name, object name namespacing/prefixing, etc.).
+
+        The headers provided are assumed to be in Swift parlance, and will be
+        converted to S3-style headers if necessary.
+
+        The contents of the object will be the concatenation of everything
+        yielded by `body_iter` before it raises StopIteration.
+
+        The optional query_string is used only for the Swift provider and is
+        sent on, verbatim, to the underlying swiftclient put_object() call.
+        """
+        raise NotImplementedError()
+
     def upload_object(self, swift_key, storage_policy_index, internal_client):
         raise NotImplementedError()
 

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -16,12 +16,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from itertools import repeat
 import mock
-from s3_sync import utils
-from s3_sync import base_sync
+import os
 import StringIO
 import unittest
+
 from utils import FakeStream
+
+from s3_sync import utils
+from s3_sync import base_sync
 
 
 class TestUtilsFunctions(unittest.TestCase):
@@ -147,36 +151,294 @@ class TestUtilsFunctions(unittest.TestCase):
 
 
 class FakeSwift(object):
-    def __init__(self):
-        self.size = 1024
-        self.status = 200
+    def __init__(self, status=200, size=1024, content_length='UNSPECIFIED',
+                 content=None):
+        self.status = status
+        self.content = content
+        if self.content:
+            self.size = len(content)
+        else:
+            self.size = size
+        self.content_length = self.size if content_length == 'UNSPECIFIED' \
+            else content_length
 
-    def get_object(self, account, container, key, headers={}):
-        self.fake_stream = FakeStream(self.size)
-        return (self.status,
-                {'Content-Length': self.size},
-                self.fake_stream)
+    def get_object(self, account, container, key, headers=None):
+        self.got_headers = headers
+        if self.content:
+            self.fake_stream = FakeStream(content=self.content)
+        else:
+            self.fake_stream = FakeStream(self.size)
+        headers = {'X-Object-Meta-Foo': 'baR'}
+        if self.content_length is not None:
+            headers['Content-Length'] = str(self.content_length)
+        return (self.status, headers, self.fake_stream)
+
+
+class TestSeekableFileLikeIter(unittest.TestCase):
+    def setUp(self):
+        self.mock_swift = FakeSwift()
+        self.seeker = utils.SeekableFileLikeIter(['abc', 'def', 'ijk'])
+
+    def test_bounded_reading(self):
+        # Pete and Repete were in a boat; Pete fell out.  Who was left??
+        self.seeker = utils.SeekableFileLikeIter(repeat('abcd'), length=10)
+
+        self.assertEqual('abcdabcdab', ''.join(self.seeker))
+        self.assertEqual(10, self.seeker.tell())
+        self.assertEqual('', self.seeker.read())
+        self.assertEqual('', self.seeker.read(1))
+        self.assertRaises(StopIteration, self.seeker.next)
+        with self.assertRaises(StopIteration):
+            next(self.seeker)
+
+        # Seeking after reading data, without a callback, is most likely a
+        # coding bug and is explicitly disallowed.
+        self.assertRaises(RuntimeError, self.seeker.reset)
+
+    def test_close(self):
+        self.assertEqual('ab', self.seeker.read(2))
+        self.seeker.close()
+        self.seeker.close()  # idempotent
+        self.assertRaises(ValueError, self.seeker.read)
+        self.assertRaises(ValueError, self.seeker.readlines)
+        self.assertRaises(ValueError, self.seeker.next)
+        with self.assertRaises(ValueError):
+            next(self.seeker)
+
+    def test_seek_zero_with_cb(self):
+        cb = mock.Mock()
+        cb.side_effect = lambda: iter(['1', '23', '456'])
+
+        self.seeker = utils.SeekableFileLikeIter(['abc', 'def', 'ijk'],
+                                                 seek_zero_cb=cb)
+
+        self.assertEqual(0, self.seeker.tell())
+        self.seeker.seek(0)  # flag is optional
+        self.assertEqual(0, self.seeker.tell())
+        self.seeker.seek(0, os.SEEK_CUR)  # flag is actually ignored
+        # A seek-zero with no bytes read is a NOOP
+        self.assertEqual([], cb.mock_calls)
+
+        self.assertEqual('ab', self.seeker.read(2))
+        self.assertEqual(2, self.seeker.tell())
+        self.seeker.seek(0, os.SEEK_END)  # LOL
+        self.assertEqual(0, self.seeker.tell())
+        self.assertEqual('123456', ''.join(self.seeker))
+        self.assertEqual(6, self.seeker.tell())
+        self.assertEqual('', self.seeker.read())
+        self.assertEqual('', self.seeker.read(1))
+        self.assertRaises(StopIteration, self.seeker.next)
+
+    def test_seek_zero_no_cb(self):
+        self.assertEqual(0, self.seeker.tell())
+        self.seeker.seek(0, os.SEEK_CUR)  # flag is actually ignored
+        self.assertEqual(0, self.seeker.tell())
+        self.seeker.seek(0, os.SEEK_END)  # flag is actually ignored
+        self.assertEqual(0, self.seeker.tell())
+        self.seeker.seek(0, os.SEEK_SET)  # flag is actually ignored
+        self.assertEqual(0, self.seeker.tell())
+        self.seeker.reset()  # synonym for `.seek(0, ...)`
+        self.assertEqual(0, self.seeker.tell())
+
+        with self.assertRaises(RuntimeError) as cm:
+            self.seeker.seek(-1, 'I am totally ignored!')
+        self.assertEqual('SeekableFileLikeIter: '
+                         'arbitrary seeks are not supported',
+                         cm.exception.message)
+
+        with self.assertRaises(RuntimeError) as cm:
+            self.seeker.seek(1, 'I am totally ignored!')
+        self.assertEqual('SeekableFileLikeIter: '
+                         'arbitrary seeks are not supported',
+                         cm.exception.message)
+
+        self.assertEqual('ab', self.seeker.read(2))
+        self.assertEqual(2, self.seeker.tell())
+
+        # Seeking after reading data, without a callback, is most likely a
+        # coding bug and is explicitly disallowed.
+        self.assertRaises(RuntimeError, self.seeker.reset)
+
+    def test_seekable_read_all(self):
+        self.assertEqual(0, self.seeker.tell())
+        self.assertEqual('abcdefijk', ''.join(c for c in self.seeker))
+        self.assertEqual(9, self.seeker.tell())
+        self.assertEqual('', ''.join(c for c in self.seeker))
+        self.assertEqual(9, self.seeker.tell())
+
+        self.seeker = utils.SeekableFileLikeIter(['abc', 'def', 'ijk'])
+        self.assertEqual(0, self.seeker.tell())
+        self.assertEqual('abcdefijk', self.seeker.read())
+        self.assertEqual(9, self.seeker.tell())
+        self.assertEqual('', self.seeker.read())
+        self.assertEqual(9, self.seeker.tell())
+
+    def test_seekable_short_reads_and_next(self):
+        self.assertEqual('a', self.seeker.read(1))
+        self.assertEqual(1, self.seeker.tell())
+        # short read served from buffer (only)
+        self.assertEqual('bc', self.seeker.read(3))
+        self.assertEqual(3, self.seeker.tell())
+        self.assertEqual('d', self.seeker.read(1))
+        self.assertEqual(4, self.seeker.tell())
+        # read(0) is a NOP
+        self.assertEqual('', self.seeker.read(0))
+        self.assertEqual(4, self.seeker.tell())
+        # next served from buffer (only)
+        self.assertEqual('ef', next(self.seeker))
+        self.assertEqual(6, self.seeker.tell())
+        # next served from iterator
+        self.assertEqual('ijk', self.seeker.next())
+        self.assertEqual(9, self.seeker.tell())
+        # final read delivers EOF
+        self.assertEqual('', self.seeker.read(1))
 
 
 class TestFileWrapper(unittest.TestCase):
     def setUp(self):
         self.mock_swift = FakeSwift()
 
+    def test_failed_req(self):
+        self.mock_swift = FakeSwift(status=401)
+        with self.assertRaises(RuntimeError) as cm:
+            utils.FileWrapper(self.mock_swift,
+                              'account', 'container', 'key',
+                              headers={'a': 'b'})
+        self.assertEqual('Failed to get the object', cm.exception.message)
+
+    def test_no_content_length(self):
+        content = 'shimmyjimmy' * 3
+        self.mock_swift = FakeSwift(content_length=None, content=content)
+        wrapper = utils.FileWrapper(self.mock_swift,
+                                    'account',
+                                    'container',
+                                    'key', headers={'a': 'b'})
+
+        with self.assertRaises(TypeError):
+            len(wrapper)
+        self.assertEqual({
+            'X-Object-Meta-Foo': 'baR',
+        }, wrapper.get_headers())
+        self.assertEqual({
+            # gets lowercased, I guess
+            'foo': 'baR',
+        }, wrapper.get_s3_headers())
+        self.assertEqual({'a': 'b'}, self.mock_swift.got_headers)
+
+        chunk_size = wrapper._swift_stream.chunk_size
+        self.assertGreater(chunk_size, 2)
+        self.assertEqual(content[:2], wrapper.read(2))
+        self.assertEqual(content[2:chunk_size], wrapper.next())
+
+        wrapper.reset()
+        self.assertEqual(content, wrapper.read())
+
+        wrapper.reset()
+        self.assertEqual(content, ''.join(wrapper))
+
+    def test_close(self):
+        wrapper = utils.FileWrapper(self.mock_swift,
+                                    'account',
+                                    'container',
+                                    'key', headers={'a': 'b'})
+        self.assertEqual(1024, len(wrapper))
+        chunk_size = self.mock_swift.fake_stream.chunk_size
+        self.assertEqual('A' * chunk_size, next(wrapper))
+        self.assertNotEqual(None, wrapper._swift_stream)
+        wrapper.close()
+        self.assertEqual(None, wrapper._swift_stream)
+        wrapper.close()  # idemptotent
+        self.assertRaises(ValueError, wrapper.read)
+        self.assertRaises(ValueError, wrapper.readlines)
+        self.assertRaises(ValueError, wrapper.next)
+        with self.assertRaises(ValueError):
+            next(wrapper)
+
+    def test_no_content_length_then_a_content_length(self):
+        self.mock_swift = mock.Mock()
+        self.mock_swift.get_object.side_effect = [
+            (200, {}, FakeStream()),
+            (200, {'Content-Length': '1024'}, FakeStream()),
+        ]
+        wrapper = utils.FileWrapper(self.mock_swift,
+                                    'account', 'container', 'key',
+                                    headers={'a': 'b'})
+
+        with self.assertRaises(TypeError):
+            len(wrapper)
+
+        chunk_size = wrapper._swift_stream.chunk_size
+        self.assertEqual('A' * (2 * chunk_size), wrapper.read(4000) +
+                         next(wrapper))
+
+        wrapper.seek(0, 'ignored')
+
+        self.assertEqual(1024, len(wrapper))
+        self.assertEqual('A' * 1024, wrapper.read())
+
+    def test_content_length_then_no_content_length(self):
+        self.mock_swift = mock.Mock()
+        self.mock_swift.get_object.side_effect = [
+            (200, {'Content-Length': '1024'}, FakeStream()),
+            (200, {}, FakeStream()),
+        ]
+        wrapper = utils.FileWrapper(self.mock_swift,
+                                    'account', 'container', 'key',
+                                    headers={'a': 'b'})
+
+        self.assertEqual(1024, len(wrapper))
+        chunk_size = wrapper._swift_stream.chunk_size
+        self.assertEqual('A' * (2 * chunk_size), wrapper.read(4000) +
+                         next(wrapper))
+
+        wrapper.seek(0, 'ignored')
+
+        with self.assertRaises(TypeError):
+            len(wrapper)
+        self.assertEqual('A' * 1024, wrapper.read())
+
     def test_open(self):
         wrapper = utils.FileWrapper(self.mock_swift,
                                     'account',
                                     'container',
-                                    'key')
+                                    'key', headers={'a': 'b'})
         self.assertEqual(1024, len(wrapper))
+        self.assertEqual({
+            'Content-Length': '1024',
+            'X-Object-Meta-Foo': 'baR',
+        }, wrapper.get_headers())
+        self.assertEqual({
+            # gets lowercased, I guess
+            'foo': 'baR',
+        }, wrapper.get_s3_headers())
+        self.assertEqual({'a': 'b'}, self.mock_swift.got_headers)
 
     def test_seek(self):
         wrapper = utils.FileWrapper(self.mock_swift,
                                     'account',
                                     'container',
                                     'key')
-        wrapper.read(256)
+        chunk_size = self.mock_swift.fake_stream.chunk_size
+        self.assertGreater(256, chunk_size)  # sanity check
+        self.assertEqual('A' * chunk_size, wrapper.read(256))
+        self.assertEqual(chunk_size, wrapper.tell())
+        self.assertEqual(None, wrapper.buf)
+        # A short read will be of that length, leaving remainder in a buffer
+        self.assertEqual('A', wrapper.read(1))
+        self.assertEqual('A' * (chunk_size - 1), wrapper.buf)
+        self.assertEqual(chunk_size + 1, wrapper.tell())
+        # A turn of the crank will just return remaining buffer
+        got_next = wrapper.next()
+        self.assertEqual('A' * (chunk_size - 1), got_next,
+                         'Exp %d bytes, got %d' % (chunk_size - 1,
+                                                   len(got_next)))
+        self.assertEqual(2 * chunk_size, wrapper.tell())
         wrapper.seek(0)
-        self.assertEqual(0, self.mock_swift.fake_stream.current_pos)
+        self.assertEqual(0, wrapper.tell())
+        got_all = ''.join(wrapper)
+        self.assertEqual('A' * 1024, got_all,
+                         'Exp %d bytes, got %d' % (1024, len(got_all)))
+        self.assertEqual(1024, wrapper.tell())
 
 
 class TestSLOFileWrapper(unittest.TestCase):
@@ -213,7 +475,8 @@ class TestSLOFileWrapper(unittest.TestCase):
                 raise RuntimeError('unknown container')
             if key == 'part1':
                 return (200, {'Content-Length': 500}, fake_segment)
-            raise RuntimeError('unknown key')
+            raise RuntimeError('unknown key (%r, %r, %r, %r)' % (
+                account, container, key, headers))
 
         self.swift.get_object.side_effect = get_object
         slo = utils.SLOFileWrapper(self.swift, 'account', self.manifest,

--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -25,42 +25,21 @@ class FakeStream(object):
             self.content = None
         self.current_pos = 0
         self.closed = False
-
-    def read(self, size=0):
-        if self.closed:
-            raise RuntimeError('The stream is closed')
-        if self.current_pos == self.size - 1:
-            return ''
-        if size == -1 or self.current_pos + size > self.size:
-            if self.content:
-                ret = self.content[self.current_pos:]
-            else:
-                ret = 'A' * (self.size - self.current_pos)
-            self.current_pos = self.size - 1
-            return ret
-
-        if self.content:
-            ret = self.content[self.current_pos:self.current_pos + size]
-        else:
-            ret = 'A' * size
-        self.current_pos += size
-        return ret
+        self.chunk_size = self.size / 10 or 1
 
     def next(self):
-        if self.current_pos == self.size:
+        want = min(self.size - self.current_pos, self.chunk_size)
+        if want <= 0:
             raise StopIteration()
         if self.content:
-            ret = self.content[self.current_pos]
+            ret = self.content[self.current_pos:self.current_pos + want]
         else:
-            ret = 'A'
-        self.current_pos += 1
+            ret = 'A' * want
+        self.current_pos += want
         return ret
 
     def __iter__(self):
         return self
-
-    def __len__(self):
-        return self.size
 
     def close(self):
         self.closed = True


### PR DESCRIPTION
The cloud-connector will need to be able to just PUT an object, to
either S3 or Swift, sanely (i.e. accepting an iterable of body, not
requiring a known length).

Also beefs up some of the "wrapper" helper classes.

All the new and changed code has 100% line and branch unit test
coverage, AFACT.