### PR TITLE
Add cloud-connector obj GET/HEAD support

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -108,7 +108,7 @@ class BaseSync(object):
         def free_count(self):
             return self.get_semaphore.balance
 
-    def __init__(self, settings, max_conns=10, per_account=False):
+    def __init__(self, settings, max_conns=10, per_account=False, logger=None):
         """Base class that every Cloud Sync provider implementation should
         derive from. Sets up the client pool for the provider and the common
         settings.
@@ -128,7 +128,7 @@ class BaseSync(object):
         self.settings = settings
         self.account = settings['account']
         self.container = settings['container']
-        self.logger = logging.getLogger('s3-sync')
+        self.logger = logger or logging.getLogger('s3-sync')
         self._per_account = per_account
         if '/' in self.container:
             raise ValueError('Invalid container name %r' % self.container)

--- a/s3_sync/cloud_connector/auth.py
+++ b/s3_sync/cloud_connector/auth.py
@@ -26,6 +26,7 @@ from s3_sync.cloud_connector.util import (
 
 S3_PASSWD_PATH = os.path.sep + os.path.join(
     'tmp', 's3-passwd.json')
+S3_IDENTITY_ENV_KEY = 'cloud-connector.auth.s3-identity'
 
 
 class CloudConnectAuth(object):
@@ -119,6 +120,9 @@ class CloudConnectAuth(object):
         env['PATH_INFO'] = env['PATH_INFO'].replace(key_id, acct, 1)
         self.logger.debug('key id %r authorized for acct %r: %r', key_id,
                           acct, env['PATH_INFO'])
+
+        # Store the matching identity from the DB for the application to use
+        env[S3_IDENTITY_ENV_KEY] = db_entry
         return True
 
 

--- a/s3_sync/provider_factory.py
+++ b/s3_sync/provider_factory.py
@@ -18,11 +18,11 @@ from .sync_s3 import SyncS3
 from .sync_swift import SyncSwift
 
 
-def create_provider(sync_settings, max_conns, per_account=False):
+def create_provider(sync_settings, max_conns, per_account=False, logger=None):
     provider_type = sync_settings.get('protocol', None)
     if not provider_type or provider_type == 's3':
-        return SyncS3(sync_settings, max_conns, per_account)
+        return SyncS3(sync_settings, max_conns, per_account, logger)
     elif provider_type == 'swift':
-        return SyncSwift(sync_settings, max_conns, per_account)
+        return SyncSwift(sync_settings, max_conns, per_account, logger)
     else:
         raise NotImplementedError()

--- a/s3_sync/sync_s3.py
+++ b/s3_sync/sync_s3.py
@@ -89,6 +89,7 @@ class SyncS3(BaseSync):
                                              conditionally_calculate_md5)
             s3_client.meta.events.unregister('before-call.s3.UploadPart',
                                              conditionally_calculate_md5)
+
             if self._google():
                 s3_client.meta.events.unregister(
                     'before-parameter-build.s3.ListObjects',

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -29,8 +29,9 @@ from .utils import (FileWrapper, ClosingResourceIterable, check_slo,
 
 
 class SyncSwift(BaseSync):
-    def __init__(self, settings, max_conns=10, per_account=False):
-        super(SyncSwift, self).__init__(settings, max_conns, per_account)
+    def __init__(self, settings, max_conns=10, per_account=False, logger=None):
+        super(SyncSwift, self).__init__(settings, max_conns, per_account,
+                                        logger)
         # Used to verify the remote container in case of per_account uploads
         self.verified_container = False
 

--- a/test/container/cloud-connector.conf
+++ b/test/container/cloud-connector.conf
@@ -29,6 +29,7 @@ use = egg:swift#memcache
 [filter:swift3]
 use = egg:swift3#swift3
 location = us-east-1
+dns_compliant_bucket_names = False
 
 [filter:proxy-logging]
 use = egg:swift#proxy_logging

--- a/test/container/proxy-server.conf
+++ b/test/container/proxy-server.conf
@@ -77,6 +77,8 @@ use = egg:swift#dlo
 
 [filter:swift3]
 use = egg:swift3#swift3
+location = us-east-1
+dns_compliant_bucket_names = False
 
 [filter:cloud_sync_shunt]
 use = egg:swift-s3-sync#cloud-shunt

--- a/test/integration/test_cloud_connector.py
+++ b/test/integration/test_cloud_connector.py
@@ -16,10 +16,83 @@ limitations under the License.
 
 from . import TestCloudSyncBase
 
+from s3_sync.provider_factory import create_provider
+
 
 class TestCloudConnector(TestCloudSyncBase):
-    def test_auth(self):
-        # TODO actually test S3 API auth (not easy with s3cmd, at least,
-        # because there's no way to see our stub "NotImplemented" responses as
-        # any kind of success.
-        pass
+    def setUp(self):
+        super(TestCloudConnector, self).setUp()
+
+        self.mapping = self._find_mapping(
+            # NOTE: Swift container name must be a valid Amazon S3 bucket name.
+            # Also, this mapping has a `copy_after` of 3600 meaning that
+            # background daemons won't be mucking about with our objects while
+            # these tests are trying to do _their_ job.
+            lambda m: m.get('container') == u"s3-restore")
+        self.conn_noshunt = self.conn_for_acct_noshunt(u'AUTH_test')
+        self.local_to_me_provider = create_provider(self.mapping, 1, False)
+        self.cc_provider = create_provider({
+            "account": u"AUTH_test",
+            "container": "s3-restore",
+            "aws_bucket": "s3-restore",
+            "aws_endpoint": "http://localhost:8081",
+            "aws_identity": u"test:tester",
+            "aws_secret": u"testing",
+            "protocol": "s3",
+            "custom_prefix": '',
+        }, 1, False)
+
+    def test_obj_head_and_get(self):
+        # Not there yet...
+        obj_name = u'shimmy\u062ajimmy'
+
+        resp = self.cc_provider.get_object(obj_name)
+
+        self.assertEqual(404, resp.status)
+        self.assertEqual('The specified key does not exist.',
+                         ''.join(resp.body))
+
+        # Put an obj into swift
+        self.conn_noshunt.put_object(
+            self.mapping['container'], obj_name,
+            'abc', headers={'x-object-meta-slim': 'slam'})
+        # Sanity-check
+        headers = self.conn_noshunt.head_object(self.mapping['container'],
+                                                obj_name)
+        self.assertEqual('3', headers['content-length'])
+
+        resp = self.cc_provider.get_object(obj_name)
+
+        self.assertEqual(200, resp.status)
+        self.assertEqual('abc', ''.join(resp.body))
+        self.assertEqual('slam', resp.headers['x-object-meta-slim'])
+
+        # Sanity-check
+        headers = self.conn_noshunt.head_object(self.mapping['container'],
+                                                obj_name)
+        self.assertEqual('3', headers['content-length'])
+
+        # Stick a different obj in S3 and make sure that's what we get
+        self.local_to_me_provider.put_object(obj_name,
+                                             {'x-object-meta-jamm': 'bamm'},
+                                             'def')
+
+        resp = self.cc_provider.get_object(obj_name)
+
+        self.assertEqual(200, resp.status)
+        self.assertEqual('def', ''.join(resp.body))
+        self.assertEqual('bamm', resp.headers['x-object-meta-jamm'])
+
+        # Sanity-check
+        headers = self.conn_noshunt.head_object(self.mapping['container'],
+                                                obj_name)
+        self.assertEqual('3', headers['content-length'])
+
+        # And same if we delete the obj in swift
+        self.conn_noshunt.delete_object(self.mapping['container'], obj_name)
+
+        resp = self.cc_provider.get_object(obj_name)
+
+        self.assertEqual(200, resp.status)
+        self.assertEqual('def', ''.join(resp.body))
+        self.assertEqual('bamm', resp.headers['x-object-meta-jamm'])


### PR DESCRIPTION
When a S3 API object GET/HEAD request comes into cloud-connector, it first
looks in the local S3 API object store, and if that "misses", it looks in
the configured on-prem Swift object store (using the S3 API).

Also made create_provider able to plumb a logger into the provider.
Cloud-connector uses that to ensure that provider logging shows up and is
appropriately prefixed.