### PR TITLE
Add PUT path for cloud-connector

### DIFF
--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -157,7 +157,7 @@ class BaseSync(object):
             self.aws_bucket,
         )
 
-    def put_object(self, swift_key, headers, body_iter, query_string=None):
+    def put_object(self, swift_key, headers, body, query_string=None):
         """
         Uploads a single object to the provider's object store, as configured
         (container name, object name namespacing/prefixing, etc.).
@@ -165,8 +165,9 @@ class BaseSync(object):
         The headers provided are assumed to be in Swift parlance, and will be
         converted to S3-style headers if necessary.
 
-        The contents of the object will be the concatenation of everything
-        yielded by `body_iter` before it raises StopIteration.
+        The `body` argument can be a string or unicode instance, a file-like
+        object (like a wsgi.input stream wrapped by an InputProxy instance), or
+        an iterable.
 
         The optional query_string is used only for the Swift provider and is
         sent on, verbatim, to the underlying swiftclient put_object() call.

--- a/s3_sync/sync_s3.py
+++ b/s3_sync/sync_s3.py
@@ -235,21 +235,21 @@ class SyncS3(BaseSync):
             bucket = self.aws_bucket
         return self._call_boto('head_bucket', bucket, None, **options)
 
-    def put_object(self, swift_key, headers, body_iter, query_string=None):
+    def put_object(self, swift_key, headers, body, query_string=None):
         s3_key = self.get_s3_name(swift_key)
-        if isinstance(body_iter, (unicode, str)):
-            if isinstance(body_iter, unicode):
-                body_iter = body_iter.encode('utf8')
-            content_length = len(body_iter)
-            body = body_iter
+        content_length = None
+        if isinstance(body, (unicode, str)):
+            if isinstance(body, unicode):
+                body = body.encode('utf8')
+            content_length = len(body)
+            body = body
         elif headers.get('content-length'):
             content_length = int(headers['content-length'])
             # Boto seems to take a str okay, but docs indicate it wants an int
             headers['content-length'] = content_length
-            body = SeekableFileLikeIter(body_iter, length=content_length)
+            body = SeekableFileLikeIter(body, length=content_length)
         else:
-            content_length = None
-            body = SeekableFileLikeIter(body_iter)
+            body = SeekableFileLikeIter(body)
         params = dict(
             Bucket=self.aws_bucket,
             Key=s3_key,


### PR DESCRIPTION
SeekableFileLikeIter needed to be able to take an existing file-like object
(like Swift's InputProxy that wraps `wsgi.input`) while still faithfully
fulfilling its interface.  This is facilitated via the new class,
IterableFromFileLike.

[#156747774]