### PR TITLE
Remove or prune containers deleted at the source during migrations

### DIFF
--- a/s3_sync/shunt.py
+++ b/s3_sync/shunt.py
@@ -31,7 +31,8 @@ from .provider_factory import create_provider
 from .utils import (check_slo, SwiftPutWrapper, SwiftSloPutWrapper,
                     RemoteHTTPError, convert_to_local_headers,
                     response_is_complete, filter_hop_by_hop_headers,
-                    iter_listing, get_container_headers)
+                    iter_listing, get_container_headers,
+                    MigrationContainerStates, get_sys_migrator_header)
 
 
 class S3SyncProxyFSSwitch(object):
@@ -528,6 +529,9 @@ class S3SyncShunt(object):
 
     def handle_post(
             self, req, start_response, sync_profile, obj, per_account):
+        if not obj and sync_profile.get('migration'):
+            req.headers[get_sys_migrator_header('container')] =\
+                MigrationContainerStates.MODIFIED
         status, headers, app_iter = req.call_application(self.app)
 
         if not status.startswith('404'):

--- a/test/unit/test_migrator.py
+++ b/test/unit/test_migrator.py
@@ -623,7 +623,7 @@ class TestMigrator(unittest.TestCase):
             return provider_mock
 
         create_provider_mock.side_effect = check_provider
-        self.migrator.config = {'aws_bucket': '/*'}
+        self.migrator.config = {'aws_bucket': '/*', 'account': 'AUTH_migrator'}
         self.migrator._next_pass = mock.Mock()
         self.migrator.next_pass()
         self.assertEqual(buckets[0]['name'], self.migrator.config['container'])
@@ -663,7 +663,7 @@ class TestMigrator(unittest.TestCase):
             next_pass_call[0] += 1
 
         create_provider_mock.side_effect = check_provider
-        self.migrator.config = {'aws_bucket': '/*'}
+        self.migrator.config = {'aws_bucket': '/*', 'account': 'AUTH_migrator'}
         self.migrator._next_pass = mock.Mock(side_effect=check_pass_provider)
         self.migrator.next_pass()
         self.assertTrue(self.migrator.config['all_buckets'])


### PR DESCRIPTION
When migrating, if a container is removed from the origin, we may need to remove it from the destination. In some cases, the container should be preserved, but its contents pruned. Check the commit message for more details.