### PR TITLE
Fixes a pagination bug when deleting objects

### DIFF
--- a/s3_sync/migrator.py
+++ b/s3_sync/migrator.py
@@ -709,7 +709,8 @@ class Migrator(object):
                 scanned += 1
                 if remote:
                     marker = remote['name']
-        while local:
+
+        while local and (not marker or local['name'] < marker):
             # We may have objects left behind that need to be removed
             with self.ic_pool.item() as ic:
                 self._reconcile_deleted_objects(ic, container, local['name'])

--- a/test/container/swift-s3-sync.conf
+++ b/test/container/swift-s3-sync.conf
@@ -237,7 +237,7 @@
         }
     ],
     "migrator_settings": {
-        "items_chunk": 1000,
+        "items_chunk": 5,
         "log_file": "/var/log/swift-s3-migrator.log",
         "poll_interval": 1,
         "status_file": "/var/lib/swift-s3-sync/migrator.status",


### PR DESCRIPTION
Fixes the pagination issue where we were previously removing objects we shouldn't have been. This would occur if the two blob stores returning listings with differing markers and we would assume that the fact that an object is missing from the listing means it should be removed, even though it might mean that the listing hasn't got as far yet.