### PR TITLE
cloud-connector: Add obj metadata update support

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -8,6 +8,7 @@ cd "$MYDIR"
 ./scripts/rebuild_and_start_main_container
 
 ./run_unit_tests
+unit_test_status=$?
 ./scripts/ensure_cloud_connector_container_started
 
 echo Waiting for container services to start...
@@ -17,3 +18,4 @@ docker exec cloud-connector timeout 40 \
     bash -c 'until echo > /dev/tcp/localhost/8081; do sleep 0.5; done' >/dev/null 2>&1
 
 docker exec -e DOCKER=true  swift-s3-sync nosetests /swift-s3-sync/test/integration/
+exit $(($unit_test_status + $?))

--- a/s3_sync/base_sync.py
+++ b/s3_sync/base_sync.py
@@ -163,6 +163,9 @@ class BaseSync(object):
             self.aws_bucket,
         )
 
+    def post_object(self, swift_key, headers):
+        raise NotImplementedError()
+
     def put_object(self, swift_key, headers, body, query_string=None):
         """
         Uploads a single object to the provider's object store, as configured

--- a/s3_sync/sync_swift.py
+++ b/s3_sync/sync_swift.py
@@ -75,6 +75,11 @@ class SyncSwift(BaseSync):
         headers.update(self.extra_headers)
         return headers
 
+    def post_object(self, swift_key, headers):
+        return self._call_swiftclient(
+            'post_object', self.remote_container, swift_key,
+            headers=headers)
+
     def put_object(self, swift_key, headers, body_iter, query_string=None):
         return self._call_swiftclient('put_object', self.container, swift_key,
                                       contents=body_iter, headers=headers,
@@ -378,10 +383,8 @@ class SyncSwift(BaseSync):
         return resp
 
     def update_metadata(self, swift_key, metadata):
-        with self.client_pool.get_client() as swift_client:
-            swift_client.post_object(
-                self.remote_container, swift_key,
-                self._client_headers(self._get_user_headers(metadata)))
+        user_headers = self._get_user_headers(metadata)
+        self.post_object(swift_key, user_headers)
 
     def _upload_slo(self, name, swift_headers, internal_client):
         status, headers, body = internal_client.get_object(

--- a/test/container/cloud-connector.conf
+++ b/test/container/cloud-connector.conf
@@ -13,7 +13,7 @@ eventlet_debug = true
 set swift_baseurl = http://swift-s3-sync:8080
 
 [pipeline:main]
-pipeline = catch_errors gatekeeper healthcheck proxy-logging listing_formats cache swift3 cloud-connector-auth copy proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging listing_formats cache swift3 cloud-connector-auth proxy-logging proxy-server
 
 [app:proxy-server]
 # Calling this "proxy-server" in the pipeline is a little white lie to keep the
@@ -44,10 +44,6 @@ use = egg:swift#catch_errors
 
 [filter:gatekeeper]
 use = egg:swift#gatekeeper
-
-[filter:copy]
-use = egg:swift#copy
-object_post_as_copy = False
 
 [filter:listing_formats]
 use = egg:swift#listing_formats

--- a/test/unit/test_sync_swift.py
+++ b/test/unit/test_sync_swift.py
@@ -234,14 +234,15 @@ class TestSyncSwift(unittest.TestCase):
             'x-object-meta-old': 'old',
             'etag': '%s' % etag,
             'Content-Type': 'application/foo'}
+        swift_client.post_object.return_value = None
 
         self.sync_swift.upload_object(key, storage_policy, mock_ic)
 
         swift_client.post_object.assert_called_with(
-            self.aws_bucket, key,
-            {'x-object-meta-new': 'new',
-             'x-object-meta-old': 'updated',
-             'Content-Type': 'application/bar'})
+            self.aws_bucket, key, headers={
+                'x-object-meta-new': 'new',
+                'x-object-meta-old': 'updated',
+                'Content-Type': 'application/bar'})
 
     @mock.patch('s3_sync.sync_swift.swiftclient.client.Connection')
     def test_meta_unicode(self, mock_swift):
@@ -257,14 +258,14 @@ class TestSyncSwift(unittest.TestCase):
         mock_swift.return_value = swift_client
         swift_client.head_object.return_value = {
             'x-object-meta-old': 'old', 'etag': '%s' % etag}
+        swift_client.post_object.return_value = None
 
         self.sync_swift.upload_object(key, storage_policy, mock_ic)
 
         swift_client.post_object.assert_called_with(
-            self.aws_bucket,
-            key,
-            {'x-object-meta-new': '\xf0\x9f\x91\x8d',
-             'x-object-meta-old': 'updated'})
+            self.aws_bucket, key, headers={
+                'x-object-meta-new': '\xf0\x9f\x91\x8d',
+                'x-object-meta-old': 'updated'})
 
     @mock.patch('s3_sync.sync_swift.swiftclient.client.Connection')
     @mock.patch('s3_sync.sync_swift.FileWrapper')
@@ -518,12 +519,14 @@ class TestSyncSwift(unittest.TestCase):
         swift_client.get_object.return_value = ({
             'etag': etag
         }, '')
+        swift_client.post_object.return_value = None
 
         self.sync_swift.upload_object(key, storage_policy, mock_ic)
 
         swift_client.post_object.assert_called_with(
-            self.aws_bucket, key,
-            {'x-object-meta-new': 'new', 'x-object-meta-old': 'updated'})
+            self.aws_bucket, key, headers={
+                'x-object-meta-new': 'new',
+                'x-object-meta-old': 'updated'})
 
     @mock.patch('s3_sync.sync_swift.swiftclient.client.Connection')
     def test_slo_no_changes(self, mock_swift):

--- a/test/unit/test_verify.py
+++ b/test/unit/test_verify.py
@@ -363,6 +363,7 @@ class TestMainTrackClientCalls(unittest.TestCase):
             {'x-object-meta-cloud-sync': 'fabcab'},  # One extra for the DELETE
         ]
         mock_client.get_container.return_value = ({}, [])
+        mock_client.post_object.return_value = None
         exit_arg = main([
             '--protocol', 'swift',
             '--endpoint', 'https://saio:8080/auth/v1.0',
@@ -379,9 +380,9 @@ class TestMainTrackClientCalls(unittest.TestCase):
                 content_length=15, etag=mock.ANY,
                 headers={'content-type': 'text/plain'}),
             mock.call.post_object(
-                'some-bucket', 'cloud_sync_test_object',
-                {'content-type': 'text/plain',
-                 'X-Object-Meta-Cloud-Sync': 'fabcab'}),
+                'some-bucket', 'cloud_sync_test_object', headers={
+                    'content-type': 'text/plain',
+                    'X-Object-Meta-Cloud-Sync': 'fabcab'}),
             mock.call.head_object('some-bucket', 'cloud_sync_test_object',
                                   headers={}),
             mock.call.get_container('some-bucket', delimiter='', limit=1,


### PR DESCRIPTION
Via S3 API, what Swift calls an object POST is spelled as a PUT copy
request with copy source same as path and X-Amz-Metadata-Directive header
set to
"REPLACE".

This now works, with semantics that the metadata update is applied to local
store if possible, but if that fails, the post is applied to the remote
store.

The providers grew a new method, "post_object" which does about what you
expect.

NOTE: when using S3 API to "post" to an object through swift3 middleware,
new metadata is apparently merged with old metadata; I assume this is an
artifact of the Swift copy middleware being involved.

[#156747759]